### PR TITLE
Fixed inconsistencies in db migrations

### DIFF
--- a/opennem/db/migrations/versions/0c22c0ca02e8_facility_scada_interval_timestamp_field.py
+++ b/opennem/db/migrations/versions/0c22c0ca02e8_facility_scada_interval_timestamp_field.py
@@ -73,7 +73,6 @@ def upgrade():
 
     # Create indexes
     op.create_index('idx_facility_scada_facility_code_interval', 'facility_scada_new', ['facility_code', 'interval'], unique=False)
-    op.create_index('idx_facility_scada_network_id', 'facility_scada_new', ['network_id'], unique=False)
     op.create_index('idx_facility_scada_interval_facility_code', 'facility_scada_new', ['interval', 'facility_code'], unique=False)
 
     # Drop old table

--- a/opennem/db/migrations/versions/1825bf65f16a_dudetail_maxrateofchange_fields_nullable.py
+++ b/opennem/db/migrations/versions/1825bf65f16a_dudetail_maxrateofchange_fields_nullable.py
@@ -18,10 +18,8 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.alter_column("dudetail", "maxrateofchangeup", existing_type=sa.Numeric(), nullable=True, schema="mms")
-    op.alter_column("dudetail", "maxrateofchangedown", existing_type=sa.Numeric(), nullable=True, schema="mms")
+    pass
 
 
 def downgrade() -> None:
-    op.alter_column("dudetail", "maxrateofchangeup", existing_type=sa.Numeric(), nullable=False, schema="mms")
-    op.alter_column("dudetail", "maxrateofchangedown", existing_type=sa.Numeric(), nullable=False, schema="mms")
+    pass

--- a/opennem/db/migrations/versions/2408ca24684c_clean_up_indexes.py
+++ b/opennem/db/migrations/versions/2408ca24684c_clean_up_indexes.py
@@ -17,18 +17,14 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.execute(
-        """
-    drop index if exists idx_facility_scada_trading_interval_desc_facility_code;
-    drop index if exists idx_facility_scada_day_network_fueltech_aest;
-    drop index if exists idx_facility_scada_day_network_fueltech_awst;
-    drop index if exists idx_facility_scada_trading_interval_perth_day;
-    drop index if exists idx_facility_scada_trading_interval_perth_month;
-    drop index if exists idx_facility_scada_trading_interval_sydney_day;
-    drop index if exists idx_facility_scada_trading_interval_sydney_month;
-    drop index if exists idx_facility_scada_trading_interval_facility_code;
-    """
-    )
+    op.execute("drop index if exists idx_facility_scada_trading_interval_desc_facility_code;")
+    op.execute("drop index if exists idx_facility_scada_day_network_fueltech_aest;")
+    op.execute("drop index if exists idx_facility_scada_day_network_fueltech_awst;")
+    op.execute("drop index if exists idx_facility_scada_trading_interval_perth_day;")
+    op.execute("drop index if exists idx_facility_scada_trading_interval_perth_month;")
+    op.execute("drop index if exists idx_facility_scada_trading_interval_sydney_day;")
+    op.execute("drop index if exists idx_facility_scada_trading_interval_sydney_month;")
+    op.execute("drop index if exists idx_facility_scada_trading_interval_facility_code;")
 
 
 def downgrade() -> None:

--- a/opennem/db/migrations/versions/61b31447e61b_merge_heads_0917d7d2ae72_and_.py
+++ b/opennem/db/migrations/versions/61b31447e61b_merge_heads_0917d7d2ae72_and_.py
@@ -20,7 +20,8 @@ depends_on = None
 
 
 def upgrade() -> None:
-    pass
+    op.create_index("ix_stats_country_type", "stats", ["stat_type", "country"], unique=False)
+    op.create_index("ix_stats_date", "stats", [sa.text("stat_date DESC")], unique=False)
 
 
 def downgrade() -> None:

--- a/opennem/db/migrations/versions/8e4fb8e5135a_rename_milesones_dtime_to_interval.py
+++ b/opennem/db/migrations/versions/8e4fb8e5135a_rename_milesones_dtime_to_interval.py
@@ -20,6 +20,8 @@ depends_on = None
 
 
 def upgrade() -> None:
+    op.execute("drop table if exists milestones cascade")
+
     op.create_table(
         "milestones",
         sa.Column("instance_id", postgresql.UUID(as_uuid=True), nullable=False),

--- a/opennem/db/migrations/versions/9956c679a0f6_mms_interchange_fields_nullable.py
+++ b/opennem/db/migrations/versions/9956c679a0f6_mms_interchange_fields_nullable.py
@@ -19,34 +19,8 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.alter_column(
-        "mnsp_interconnector",
-        "from_region_tlf",
-        existing_type=sa.Numeric(),
-        nullable=True,
-        schema="mms",
-    )
-    op.alter_column(
-        "mnsp_interconnector",
-        "to_region_tlf",
-        existing_type=sa.Numeric(),
-        nullable=True,
-        schema="mms",
-    )
+    pass
 
 
 def downgrade() -> None:
-    op.alter_column(
-        "mnsp_interconnector",
-        "from_region_tlf",
-        existing_type=sa.Numeric(),
-        nullable=False,
-        schema="mms",
-    )
-    op.alter_column(
-        "mnsp_interconnector",
-        "to_region_tlf",
-        existing_type=sa.Numeric(),
-        nullable=False,
-        schema="mms",
-    )
+    pass

--- a/opennem/db/migrations/versions/b207a3b6c080_cleanup_revisions.py
+++ b/opennem/db/migrations/versions/b207a3b6c080_cleanup_revisions.py
@@ -56,7 +56,6 @@ def upgrade() -> None:
     )
     op.drop_constraint("fk_facility_station_code", "facility", type_="foreignkey")
     op.create_foreign_key("fk_facility_station_code", "facility", "station", ["station_id"], ["id"])
-    op.create_index("idx_location_boundary", "location", ["boundary"], unique=False, postgresql_using="gist")
     op.add_column("milestones", sa.Column("network_region", sa.Text(), nullable=True))
     op.add_column("milestones", sa.Column("fueltech_group_id", sa.Text(), nullable=True))
     op.alter_column("milestones", "record_id", existing_type=sa.UUID(), type_=sa.Text(), existing_nullable=False)


### PR DESCRIPTION
Fixed all issues with db migrations, e.g duplication of tables, indexes, multiple commands in one statement, outdated tables