### PR TITLE
docs: replace dead Discord link with community page

### DIFF
--- a/docs/community.mdx
+++ b/docs/community.mdx
@@ -1,0 +1,43 @@
+---
+title: 'Community'
+description: 'Join the OpenElectricity community'
+icon: 'users'
+---
+
+# Community
+
+Join the OpenElectricity community to get help, share ideas, and contribute to the project.
+
+## GitHub
+
+The OpenElectricity project is open source and hosted on GitHub. You can find the source code, report issues, and contribute to the project:
+
+* [OpenElectricity GitHub Organization](https://github.com/opennem)
+* [Main Repository (opennem)](https://github.com/opennem/opennem)
+* [Report Issues](https://github.com/opennem/opennem/issues)
+
+## Social Media
+
+Follow us on social media for updates and announcements:
+
+* [Twitter: @opennem](https://twitter.com/opennem)
+
+## Slack Community
+
+Join our Slack workspace to connect with other users and developers:
+
+* **Slack Workspace**: [opennem.slack.com](https://opennem.slack.com)
+* **Get an Invite**: Email [enquiries@opennem.org.au](mailto:enquiries@opennem.org.au) to request an invitation
+
+## Get Help
+
+If you need help with OpenElectricity:
+
+1. Check the [documentation](/introduction) and [guides](/guides/networks)
+2. Search existing [GitHub issues](https://github.com/opennem/opennem/issues)
+3. Join our [Slack workspace](https://opennem.slack.com) (email [enquiries@opennem.org.au](mailto:enquiries@opennem.org.au) for an invite)
+4. Create a new [GitHub issue](https://github.com/opennem/opennem/issues/new) if you find a bug or have a feature request
+
+## Contributing
+
+We welcome contributions to the OpenElectricity project! Check out our [contribution guide](/contribute/overview) to get started.

--- a/docs/contribute/backend/cli.mdx
+++ b/docs/contribute/backend/cli.mdx
@@ -233,7 +233,7 @@ For issues with the CLI:
 2. Verify environment variables
 3. Ensure database connectivity
 4. Check the [GitHub issues](https://github.com/opennem/opennem/issues)
-5. Join the OpenNEM community on [Discord](https://discord.gg/opennem)
+5. Join the [OpenElectricity community](/community)
 
 ## Contributing
 


### PR DESCRIPTION
- Remove dead Discord invite link from CLI documentation
- Create new community.mdx page with GitHub, Twitter, and Slack links
- Include instructions to email enquiries@opennem.org.au for Slack invite
- Update CLI docs to reference new community page

Fixes #441

🤖 Generated with [Claude Code](https://claude.ai/code)