### PR TITLE
docs: fix typos and broken link in introduction

### DIFF
--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -4,11 +4,11 @@ description: 'An Introduction to Open Electricity'
 icon: 'house'
 ---
 
-<Note>Open Electricity is currently in the process of being renamed from OpenNEM. There are still some repostories and projects yet to be renamed</Note>
+<Note>Open Electricity is currently in the process of being renamed from OpenNEM. There are still some repositories and projects yet to be renamed</Note>
 
 Open Electricity (formerly OpenNEM) is a platform for tracking and visualizing energy data from across Australia.
 
-The Open Electricity project aims to make energy network data accessible to a wider audience of users and developersthrough a website portal and data access API's and tools.
+The Open Electricity project aims to make energy network data accessible to a wider audience of users and developers through a website portal and data access API's and tools.
 
 <img
   className="block"
@@ -48,7 +48,7 @@ Currently supported electricity networks and data sources:
 
 ## About Open Electricity
 
-Open Electricity is a project of [The Superpower Institute](https://https://www.superpowerinstitute.com.au/), a not-for-profit organisation
+Open Electricity is a project of [The Superpower Institute](https://www.superpowerinstitute.com.au/), a not-for-profit organisation
 dedicated to accelerating the transition to a clean energy future. All [code](https://github.com/opennem) is open source and licensed under
 the [MIT License](https://opensource.org/licenses/MIT). All data is made available under the [Creative Commons Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)](https://creativecommons.org/licenses/by-nc/4.0/) licence — see the [full licence](https://platform.openelectricity.org.au/license) for details.
 


### PR DESCRIPTION
Fixed the following in introduction.mdx:

- Corrected spelling of "repositories".

- Added missing space in "developers through".

- Fixed broken link due to double https:// protocol in the Superpower Institute link.