### PR TITLE
docs: Developer Overview link to tracker website has an extra "r"

### DIFF
--- a/docs/contribute/overview.mdx
+++ b/docs/contribute/overview.mdx
@@ -10,4 +10,4 @@ The OpenNEM project ([GitHub organization `opennem`](https://github.com/opennem/
 
  * `opennem` - [GitHub](https://github.com/opennem/opennem)  - GitHub project name `opennem`. The primary backend stack that crawls all the data sources, parses them, generates outputs, the database schema and the API interface for integrations. The primary development language is Python.
  * `openelectricity` - [GitHub](https://github.com/opennem/openelectricity) - The Open Electricity website.
- * `opennem-fe` - [GitHub](https://github.com/opennem/opennem-fe) - This is the web frontend for the Open Electricity [data tracker website](https://explorer.openelectricity.org.au)
+ * `opennem-fe` - [GitHub](https://github.com/opennem/opennem-fe) - This is the web frontend for the Open Electricity [data tracker website](https://explore.openelectricity.org.au)

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -21,7 +21,7 @@ The Open Electricity project consists of two major components: the website and t
 
 ## Website
 
-The [Open Electricity website](https://explorer.openelectricity.org.au) is a public website that provides a tracker for energy data from across Australia.
+The [Open Electricity website](https://explore.openelectricity.org.au) is a public website that provides a tracker for energy data from across Australia.
 
  * Explore energy data from across Australia
  * [Facilities](https://explore.openelectricity.org.au/facilities/nem/): Map of Australian power station facilities and their data.


### PR DESCRIPTION
Fixes #484

Fix links in documentation to use the correct domain for the Open Electricity website