### PR TITLE
fix(api): capacity_history fall back to capacity_registered

### DIFF
--- a/opennem/queries/capacity_history.py
+++ b/opennem/queries/capacity_history.py
@@ -51,13 +51,14 @@ async def get_capacity_history(
             f.network_id,
             f.network_region,
             u.fueltech_id,
-            SUM(u.capacity_maximum) AS total_capacity
+            -- WEM units mostly lack capacity_maximum; fall back to capacity_registered
+            SUM(COALESCE(u.capacity_maximum, u.capacity_registered)) AS total_capacity
         FROM monthly_buckets mb
         CROSS JOIN units u
         INNER JOIN facilities f ON u.station_id = f.id
         WHERE
             u.fueltech_id IS NOT NULL
-            AND u.capacity_maximum IS NOT NULL
+            AND COALESCE(u.capacity_maximum, u.capacity_registered) IS NOT NULL
             AND u.commencement_date IS NOT NULL
             AND f.network_id IN ('NEM', 'WEM')
             AND u.fueltech_id NOT IN ('battery', 'solar_rooftop')

--- a/opennem/social/content.py
+++ b/opennem/social/content.py
@@ -55,8 +55,8 @@ def build_record_url(record_id: str, focus_ts_ms: int) -> str:
 
 CARD_WIDTH = 1200
 CARD_HEIGHT = 630
-SPARKLINE_VIEW_W = 1052  # 1200 - 2*60 padding - 2*24 inner padding
-SPARKLINE_VIEW_H = 110
+SPARKLINE_VIEW_W = 1088  # 1200 - 2*56 card padding
+SPARKLINE_VIEW_H = 290  # matches rendered container aspect so circle stays round
 
 
 def _icon_color(fueltech_id: str | None) -> str:
@@ -163,9 +163,10 @@ def _build_sparkline_svg(
         )
 
     values = [v for _, v in points]
-    vmin, vmax = min(values), max(values)
-    if vmax == vmin:
-        vmin = vmax - 1
+    vmin = 0.0
+    vmax = max(values)
+    if vmax <= 0:
+        vmax = 1.0
     # Padding inside the viewBox so the focus dot (r=8 + stroke 3) doesn't clip
     pad_y = 16
     pad_x_left = 6
@@ -191,13 +192,11 @@ def _build_sparkline_svg(
 
     return (
         f'<svg class="sparkline-svg" viewBox="0 0 {SPARKLINE_VIEW_W} {SPARKLINE_VIEW_H}" '
-        f'xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none" overflow="visible">'
+        f'xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">'
         f'<path d="{area_d}" fill="{color}" fill-opacity="0.12" stroke="none"/>'
         f'<path d="{d}" fill="none" stroke="{color}" stroke-width="2.5" '
         f'stroke-linecap="round" stroke-linejoin="round"/>'
-        # Focus dot — drawn last, scaled by JS would not clip; use larger r to compensate for aspect-ratio squish
-        f'<circle cx="{fx:.1f}" cy="{fy:.1f}" r="6" fill="white" stroke="black" stroke-width="2.5" '
-        f'vector-effect="non-scaling-stroke"/>'
+        f'<circle cx="{fx:.1f}" cy="{fy:.1f}" r="6" fill="white" stroke="black" stroke-width="2.5"/>'
         f"</svg>"
     )
 
@@ -255,6 +254,7 @@ def render_milestone_card(
     html = serve_template(
         "record_card.html",
         title=title,
+        description=description or record_id,
         region=region,
         ft_color=ft_color,
         icon_color=icon_color,

--- a/opennem/templates/record_card.html
+++ b/opennem/templates/record_card.html
@@ -8,17 +8,19 @@
   * { margin: 0; padding: 0; box-sizing: border-box; }
 
   :root {
-    --green:    #2EC42B;
-    --red:      #F25151;
+    /* Status */
+    --green:    #70D26E;
+    --red:      #FA6060;
 
+    /* Typography */
     --text-primary:   #000000;
     --text-secondary: #353535;
     --text-tertiary:  #6A6A6A;
 
-    --surface-bg:   #FAF9F6;
-    --tile-bg:      #FFFFFF;
-    --row-border:   #F1F0ED;
-    --record-bg:    #F4F2EB;
+    /* Surfaces */
+    --surface-bg:   #F1F0ED;
+    --tile-bg:      #FAF9F6;
+    --row-border:   #E5E3DE;
   }
 
   body {
@@ -33,44 +35,50 @@
 
   .card {
     height: 100%;
-    padding: 40px 56px 28px;
+    padding: 48px 56px 32px;
     display: flex;
     flex-direction: column;
+    gap: 24px;
   }
 
   /* ---- Header ---- */
   .header {
     display: flex;
-    gap: 28px;
-    align-items: flex-start;
-    margin-bottom: 22px;
+    gap: 24px;
+    align-items: stretch;
   }
+
   .header-left {
     flex: 1 1 0;
     min-width: 0;
     display: flex;
-    flex-direction: column;
-    gap: 18px;
-    padding-top: 4px;
+    align-items: center;
+    gap: 22px;
   }
   .ft-badge {
-    width: 64px;
-    height: 64px;
+    width: 72px;
+    height: 72px;
     border-radius: 50%;
     display: flex;
     align-items: center;
     justify-content: center;
     flex-shrink: 0;
   }
-  .ft-badge svg { width: 32px; height: 32px; }
+  .ft-badge svg { width: 38px; height: 38px; }
 
+  .header-title-wrap {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    min-width: 0;
+  }
   .record-title {
     font-family: 'DM Sans', sans-serif;
-    font-size: 40px;
-    font-weight: 600;
-    line-height: 46px;
+    font-size: 38px;
+    font-weight: 700;
+    line-height: 44px;
     letter-spacing: -0.01em;
-    color: var(--text-primary);
+    color: var(--text-secondary);
   }
   .record-region {
     font-family: 'DM Mono', monospace;
@@ -78,58 +86,44 @@
     font-weight: 400;
     color: var(--text-tertiary);
     text-transform: uppercase;
-    letter-spacing: 0.04em;
-    margin-top: 4px;
+    letter-spacing: 0.06em;
   }
 
   .header-right {
     flex-shrink: 0;
-    background: var(--record-bg);
-    border-radius: 12px;
-    padding: 18px 24px 16px;
+    background: var(--tile-bg);
+    border-radius: 8px;
+    padding: 20px 28px 18px;
     display: flex;
     flex-direction: column;
     gap: 4px;
-    min-width: 260px;
-    border: 1px solid var(--row-border);
+    min-width: 320px;
   }
   .record-set-label {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    font-family: 'Space Grotesk', sans-serif;
-    font-size: 16px;
+    font-family: 'DM Sans', sans-serif;
+    font-size: 18px;
     font-weight: 500;
-    color: var(--text-tertiary);
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
-  }
-  .record-set-dot {
-    width: 14px;
-    height: 14px;
-    background: black;
-    border: 3px solid white;
-    border-radius: 50%;
-    box-shadow: 0 0 0 1px var(--text-tertiary);
+    line-height: 22px;
+    color: var(--text-primary);
   }
   .record-set-date {
-    font-family: 'DM Sans', sans-serif;
-    font-size: 22px;
-    font-weight: 500;
-    color: var(--text-secondary);
-    margin-top: 2px;
+    font-family: 'DM Mono', monospace;
+    font-size: 16px;
+    font-weight: 400;
+    color: var(--text-tertiary);
+    margin-bottom: 6px;
   }
   .record-value-row {
     display: flex;
     align-items: baseline;
-    gap: 10px;
-    margin-top: 6px;
+    gap: 12px;
+    margin-top: 4px;
   }
   .record-value {
     font-family: 'DM Mono', monospace;
-    font-size: 50px;
+    font-size: 48px;
     font-weight: 500;
-    line-height: 54px;
+    line-height: 52px;
     color: var(--text-primary);
     font-variant-numeric: tabular-nums;
   }
@@ -140,9 +134,9 @@
     color: var(--text-tertiary);
   }
   .record-change {
-    margin-top: 6px;
+    margin-top: 4px;
     font-family: 'DM Mono', monospace;
-    font-size: 18px;
+    font-size: 20px;
     font-weight: 500;
     display: inline-flex;
     align-items: center;
@@ -150,26 +144,32 @@
   }
   .record-change.up   { color: var(--green); }
   .record-change.down { color: var(--red); }
+  .record-change.flat { color: var(--text-tertiary); }
 
   /* ---- Sparkline ---- */
   .sparkline-wrap {
-    height: 180px;
+    flex: 1 1 auto;
     background: var(--tile-bg);
-    border-radius: 12px;
-    padding: 18px 24px 14px;
+    border-radius: 8px;
+    padding: 22px 28px 18px;
     display: flex;
     flex-direction: column;
-    gap: 6px;
-    border: 1px solid var(--row-border);
+    gap: 10px;
+    min-height: 0;
   }
   .sparkline-meta {
     display: flex;
     justify-content: space-between;
     align-items: center;
     font-family: 'DM Mono', monospace;
-    font-size: 14px;
+    font-size: 15px;
     color: var(--text-tertiary);
     flex-shrink: 0;
+  }
+  .sparkline-meta .period {
+    font-weight: 500;
+    color: var(--text-secondary);
+    letter-spacing: 0.06em;
   }
   .sparkline-svg {
     flex: 1 1 auto;
@@ -177,34 +177,45 @@
     display: block;
   }
 
+  /* ---- Description ---- */
+  .record-description {
+    font-family: 'DM Sans', sans-serif;
+    font-size: 22px;
+    font-weight: 500;
+    line-height: 30px;
+    color: var(--text-secondary);
+    flex-shrink: 0;
+    padding: 0 4px;
+  }
+
   /* ---- Footer ---- */
   .footer {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    margin-top: 14px;
-    padding-top: 10px;
+    padding-top: 16px;
     border-top: 1px solid var(--row-border);
     flex-shrink: 0;
   }
   .footer-source {
     font-family: 'DM Sans', sans-serif;
-    font-size: 14px;
+    font-size: 16px;
     color: var(--text-tertiary);
   }
   .footer-logo {
     display: flex;
     align-items: flex-end;
-    gap: 6px;
+    gap: 8px;
     color: var(--text-primary);
   }
   .footer-logo-text {
     font-family: 'Space Grotesk', sans-serif;
-    font-size: 22px;
+    font-size: 26px;
     font-weight: 700;
     letter-spacing: -0.01em;
+    line-height: 1;
   }
-  .footer-logo-mark { width: 16px; height: 8px; margin-bottom: 5px; }
+  .footer-logo-mark { width: 18px; height: 9px; margin-bottom: 5px; }
 </style>
 </head>
 <body>
@@ -216,7 +227,7 @@
       <div class="ft-badge" style="background-color: ${ft_color}; color: ${icon_color};">
         ${icon_svg}
       </div>
-      <div>
+      <div class="header-title-wrap">
         <div class="record-title">${title}</div>
         % if region:
         <div class="record-region">${region}</div>
@@ -225,10 +236,7 @@
     </div>
 
     <div class="header-right">
-      <div class="record-set-label">
-        <span class="record-set-dot"></span>
-        Record set
-      </div>
+      <div class="record-set-label">Record set</div>
       <div class="record-set-date">${set_date}</div>
       <div class="record-value-row">
         <span class="record-value">${value_str}</span>
@@ -246,10 +254,13 @@
   <div class="sparkline-wrap">
     <div class="sparkline-meta">
       <span>${history_label}</span>
-      <span>${period_label}</span>
+      <span class="period">${period_label}</span>
     </div>
     ${sparkline_svg}
   </div>
+
+  <!-- Description -->
+  <div class="record-description">${description}</div>
 
   <!-- Footer -->
   <div class="footer">

--- a/opennem/templates/weekly_summary_image.html
+++ b/opennem/templates/weekly_summary_image.html
@@ -13,12 +13,12 @@
     --wind:     #2C7629;
     --hydro:    #5EA0C0;
     --battery:  #3245C9;
-    --gas:      #F48E1B;
+    --gas:      #E15C34;
     --coal:     #25221C;
 
     /* Status */
-    --green:    #2EC42B;
-    --red:      #F25151;
+    --green:    #70D26E;
+    --red:      #FA6060;
 
     /* Typography */
     --text-primary:   #000000;
@@ -26,9 +26,8 @@
     --text-tertiary:  #6A6A6A;
 
     /* Surfaces */
-    --surface-bg:   #FAF9F6;
-    --tile-bg:      #FFFFFF;
-    --row-bg:       #FFFFFF;
+    --surface-bg:   #F1F0ED;
+    --tile-bg:      #FAF9F6;
     --row-border:   #F1F0ED;
   }
 
@@ -42,10 +41,10 @@
   }
 
   .card {
-    padding: 72px 56px 56px;
+    padding: 72px 48px 56px;
     display: flex;
     flex-direction: column;
-    gap: 32px;
+    gap: 28px;
   }
 
   /* ---- Header ---- */
@@ -58,7 +57,7 @@
     flex: 1 0 0;
     display: flex;
     flex-direction: column;
-    gap: 8px;
+    gap: 6px;
   }
   .header-title {
     font-family: 'DM Sans', sans-serif;
@@ -66,18 +65,18 @@
     font-weight: 700;
     line-height: 52px;
     letter-spacing: -0.01em;
-    color: var(--text-primary);
+    color: var(--text-secondary);
   }
   .header-date {
     font-family: 'DM Sans', sans-serif;
-    font-size: 22px;
+    font-size: 28px;
     font-weight: 400;
-    line-height: 28px;
+    line-height: 36px;
     color: var(--text-tertiary);
   }
   .header-map {
-    width: 110px;
-    height: 104px;
+    width: 108px;
+    height: 102px;
     flex-shrink: 0;
   }
   .header-map svg { width: 100%; height: 100%; display: block; }
@@ -93,86 +92,81 @@
     padding: 26px 28px 22px;
     display: flex;
     flex-direction: column;
-    gap: 14px;
+    gap: 10px;
     flex: 1 0 0;
     min-width: 0;
   }
   .kpi-label {
     font-family: 'DM Sans', sans-serif;
-    font-size: 22px;
+    font-size: 26px;
     font-weight: 500;
-    line-height: 28px;
-    color: var(--text-secondary);
+    line-height: 32px;
+    color: var(--text-primary);
     white-space: nowrap;
-  }
-  .kpi-values {
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
   }
   .kpi-primary {
     display: flex;
     align-items: baseline;
-    gap: 6px;
+    gap: 20px;
     white-space: nowrap;
+  }
+  .kpi-value-wrap {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
   }
   .kpi-value {
     font-family: 'DM Mono', monospace;
-    font-size: 40px;
+    font-size: 44px;
     font-weight: 500;
-    line-height: 44px;
+    line-height: 48px;
     color: var(--text-primary);
     font-variant-numeric: tabular-nums;
   }
   .kpi-unit {
     font-family: 'DM Mono', monospace;
-    font-size: 22px;
+    font-size: 26px;
     font-weight: 400;
-    line-height: 44px;
+    line-height: 48px;
     color: var(--text-tertiary);
   }
   .kpi-change {
     display: flex;
-    align-items: center;
+    align-items: baseline;
     gap: 4px;
     font-family: 'DM Mono', monospace;
-    font-size: 22px;
+    font-size: 26px;
     font-weight: 500;
-    line-height: 28px;
+    line-height: 48px;
   }
-  .kpi-change.up   { color: var(--green); }
-  .kpi-change.down { color: var(--red); }
-  .kpi-change.flat { color: var(--text-tertiary); }
+  .kpi-change.wow-up   { color: var(--green); }
+  .kpi-change.wow-down { color: var(--red); }
+  .kpi-change.wow-flat { color: var(--text-tertiary); }
 
   /* ---- Source bar table ---- */
   .source-table {
-    background: var(--row-bg);
+    background: var(--tile-bg);
     border-radius: 8px;
     overflow: hidden;
   }
   .source-row {
     display: flex;
     align-items: center;
-    height: 86px;
+    height: 76px;
     gap: 28px;
-    padding: 0 28px 0 0;
-    border-bottom: 1px solid var(--row-border);
+    padding-right: 28px;
+    border-bottom: 1px solid var(--surface-bg);
   }
   .source-row:last-child { border-bottom: none; }
 
   .source-label {
-    width: 280px;
-    flex-shrink: 0;
+    flex: 1 1 0;
     display: flex;
     align-items: center;
-    gap: 14px;
+    gap: 16px;
     padding-left: 28px;
-  }
-  .source-dot {
-    width: 16px;
-    height: 16px;
-    border-radius: 50%;
-    flex-shrink: 0;
+    min-width: 0;
+    overflow: hidden;
   }
   .source-name {
     font-family: 'DM Sans', sans-serif;
@@ -180,39 +174,49 @@
     font-weight: 500;
     color: var(--text-primary);
     white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .source-dot {
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    flex-shrink: 0;
   }
   .source-bar-area {
-    flex: 1;
+    width: 300px;
+    flex-shrink: 0;
+    align-self: stretch;
     display: flex;
-    align-items: center;
+    align-items: stretch;
+    justify-content: flex-end;
   }
   .source-bar {
-    height: 22px;
-    border-radius: 3px;
-    min-width: 8px;
+    align-self: stretch;
+    min-width: 6px;
   }
   .source-gwh {
     display: flex;
     align-items: baseline;
     justify-content: flex-end;
-    gap: 4px;
-    width: 170px;
+    gap: 6px;
+    width: 150px;
     flex-shrink: 0;
     font-family: 'DM Mono', monospace;
     font-variant-numeric: tabular-nums;
   }
   .source-gwh-val {
-    font-size: 24px;
+    font-size: 26px;
     font-weight: 500;
     color: var(--text-primary);
   }
   .source-gwh-unit {
-    font-size: 18px;
+    font-size: 22px;
     font-weight: 400;
     color: var(--text-tertiary);
   }
   .source-share {
-    width: 90px;
+    width: 100px;
     flex-shrink: 0;
     text-align: right;
     font-family: 'DM Mono', monospace;
@@ -224,15 +228,18 @@
   .source-change {
     width: 100px;
     flex-shrink: 0;
-    text-align: right;
+    display: flex;
+    align-items: baseline;
+    justify-content: flex-end;
+    gap: 6px;
     font-family: 'DM Mono', monospace;
     font-size: 22px;
     font-weight: 500;
     font-variant-numeric: tabular-nums;
   }
-  .source-change.up   { color: var(--green); }
-  .source-change.down { color: var(--red); }
-  .source-change.flat { color: var(--text-tertiary); }
+  .source-change.wow-up   { color: var(--green); }
+  .source-change.wow-down { color: var(--red); }
+  .source-change.wow-flat { color: var(--text-tertiary); }
 
   /* ---- Milestones ---- */
   .milestones-section {
@@ -294,7 +301,7 @@
   }
   .mc-divider {
     height: 1px;
-    background: var(--row-border);
+    background: var(--surface-bg);
     margin: 12px 0 10px;
   }
   .mc-footer {
@@ -329,36 +336,38 @@
     font-family: 'DM Mono', monospace;
     font-size: 16px;
   }
-  .mc-change.up   { color: var(--green); }
-  .mc-change.down { color: var(--red); }
-  .mc-change.flat { color: var(--text-tertiary); }
+  .mc-change.wow-up   { color: var(--green); }
+  .mc-change.wow-down { color: var(--red); }
+  .mc-change.wow-flat { color: var(--text-tertiary); }
 
   /* ---- Footer ---- */
   .footer {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding-top: 18px;
-    border-top: 1px solid var(--row-border);
+    margin-top: 28px;
+    padding-top: 24px;
+    border-top: 1px solid #E5E3DE;
   }
   .footer-source {
     font-family: 'DM Sans', sans-serif;
-    font-size: 16px;
+    font-size: 18px;
     color: var(--text-tertiary);
   }
   .footer-logo {
     display: flex;
     align-items: flex-end;
-    gap: 6px;
+    gap: 8px;
     color: var(--text-primary);
   }
   .footer-logo-text {
     font-family: 'Space Grotesk', sans-serif;
-    font-size: 26px;
+    font-size: 32px;
     font-weight: 700;
     letter-spacing: -0.01em;
+    line-height: 1;
   }
-  .footer-logo-mark { width: 18px; height: 9px; margin-bottom: 6px; }
+  .footer-logo-mark { width: 22px; height: 11px; margin-bottom: 5px; }
 </style>
 </head>
 <body>
@@ -376,32 +385,38 @@
   <!-- KPI tiles -->
   <div class="kpi-row">
     <div class="kpi-tile">
-      <div class="kpi-label">Tot. Generation</div>
-      <div class="kpi-values">
-        <div class="kpi-primary">
+      <div class="kpi-label">Total Generation</div>
+      <div class="kpi-primary">
+        <div class="kpi-value-wrap">
           <span class="kpi-value">${total_energy}</span>
           <span class="kpi-unit">GWh</span>
         </div>
-        <div class="kpi-change ${te_wow_class.replace('wow-', '')}">${te_wow_str}</div>
+        % if te_wow_str:
+        <div class="kpi-change ${te_wow_class}">${te_wow_str}</div>
+        % endif
       </div>
     </div>
     <div class="kpi-tile">
       <div class="kpi-label">Renewables</div>
-      <div class="kpi-values">
-        <div class="kpi-primary">
+      <div class="kpi-primary">
+        <div class="kpi-value-wrap">
           <span class="kpi-value">${renewable_pct}%</span>
         </div>
-        <div class="kpi-change ${rp_wow_class.replace('wow-', '')}">${rp_wow_str}</div>
+        % if rp_wow_str:
+        <div class="kpi-change ${rp_wow_class}">${rp_wow_str}</div>
+        % endif
       </div>
     </div>
     <div class="kpi-tile">
-      <div class="kpi-label">Avg. Price</div>
-      <div class="kpi-values">
-        <div class="kpi-primary">
+      <div class="kpi-label">Avg Price</div>
+      <div class="kpi-primary">
+        <div class="kpi-value-wrap">
           <span class="kpi-value">$${avg_price}</span>
           <span class="kpi-unit">/MWh</span>
         </div>
-        <div class="kpi-change ${ap_wow_class.replace('wow-', '')}">${ap_wow_str}</div>
+        % if ap_wow_str:
+        <div class="kpi-change ${ap_wow_class}">${ap_wow_str}</div>
+        % endif
       </div>
     </div>
   </div>
@@ -412,7 +427,7 @@
     <div class="source-row">
       <div class="source-label">
         <div class="source-dot" style="background: ${r.fueltech_color};"></div>
-        <div class="source-name">${r.fueltech_label}</div>
+        <div class="source-name">${r.fueltech_label.replace('Battery (Discharging)', 'Battery (D)').replace('Battery (Charging)', 'Battery (C)')}</div>
       </div>
       <div class="source-bar-area">
         <div class="source-bar" style="width: ${r.bar_pct}%; background: ${r.fueltech_color};"></div>
@@ -422,12 +437,12 @@
         <span class="source-gwh-unit">GWh</span>
       </div>
       <div class="source-share">${r.pct_str}%</div>
-      <div class="source-change ${r.wow_class.replace('wow-', '')}">${r.wow_str}</div>
+      <div class="source-change ${r.wow_class}">${r.wow_str}</div>
     </div>
     % endfor
   </div>
 
-  <!-- Milestones (kept from existing design, restyled) -->
+  <!-- Milestones (kept; restyled for new palette) -->
   % if milestones:
   <div class="milestones-section">
     <div class="section-label">Records &amp; milestones</div>
@@ -449,7 +464,7 @@
         <div class="mc-sub">
           <span class="mc-date">${m.date_str}</span>
           % if m.change_str:
-          <span class="mc-change ${m.change_class.replace('wow-', '')}">${m.change_str}</span>
+          <span class="mc-change ${m.change_class}">${m.change_str}</span>
           % endif
         </div>
       </div>


### PR DESCRIPTION
fixes #528

wem capacity charts were missing whole fueltechs (coal, gas_ccgt, distillate) and undercounting gas_ocgt/wind.

cause: `get_capacity_history()` summed/filtered on `capacity_maximum`, which is NULL for most wem units (only 26/105 set). they carry `capacity_registered` instead.

fix: `COALESCE(capacity_maximum, capacity_registered)` for the sum and the not-null filter. nem unaffected where capacity_maximum exists; 123 nem units without it also recovered.

verified against prod — wem now resolves coal_black 1178MW, gas_ccgt 578MW, gas_ocgt 2663MW, distillate 105MW, wind 1106MW (live capacity, current month).