### PR TITLE
feat(crawler): WEMDE dispatch solution feed as near-real-time WEM source

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,4 @@
+.env
+.env.*
+.envrc
+.secrets.baseline

--- a/opennem/clients/wemde.py
+++ b/opennem/clients/wemde.py
@@ -141,6 +141,84 @@ async def wemde_parse_facilityscada(url: str) -> list[FacilityScadaSchema]:
     return models
 
 
+async def wemde_parse_dispatch(url: str) -> list[FacilityScadaSchema]:
+    """Parses a WEMDE dispatch solution file.
+
+    Uses the cleared `energy` market dispatch quantity (MW) per facility as the WEM
+    generation signal. Dispatch solutions publish as 5-min files ~5 min behind real
+    time — vs the facilityScada feed's ~24h lag. `quantity` is MW (negative = charging).
+    """
+
+    download_jsons = await _wemde_download_dataset(url)
+
+    # Get battery unit mappings
+    battery_unit_map = await get_battery_unit_map()
+
+    def _is_battery_unit(facility_code: str) -> bool:
+        return facility_code in battery_unit_map
+
+    original_records: list[dict] = []
+    battery_records: list[dict] = []
+
+    for download_json in download_jsons:
+        for interval_entry in download_json.get("solutionData", []):
+            interval = datetime.fromisoformat(interval_entry["dispatchInterval"]).replace(tzinfo=None)
+
+            energy_schedule = next(
+                (s for s in interval_entry.get("schedule", []) if s.get("marketService") == "energy"),
+                None,
+            )
+
+            if not energy_schedule:
+                continue
+
+            for facility in energy_schedule.get("facilitySchedule", []):
+                quantity = facility.get("quantity") or 0.0  # MW
+
+                record_data = {
+                    "network_id": "WEM",
+                    "interval": interval,
+                    "facility_code": facility.get("facilityCode"),
+                    "generated": quantity,
+                    "energy": quantity / 12,  # MWh in a 5-min interval
+                    "energy_quality_flag": 2,
+                }
+
+                original_records.append(record_data)
+
+                if _is_battery_unit(record_data["facility_code"]):
+                    battery_records.append(record_data)
+
+    # Create battery charge/discharge split records alongside the bidirectional records
+    all_records = original_records.copy()
+
+    for battery_record in battery_records:
+        battery_map = battery_unit_map[battery_record["facility_code"]]
+        generated = battery_record["generated"]
+
+        if generated < 0:
+            charge_record = battery_record.copy()
+            charge_record["facility_code"] = battery_map.charge_unit
+            charge_record["generated"] = abs(generated)
+            charge_record["energy"] = abs(battery_record["energy"])
+            all_records.append(charge_record)
+        else:
+            discharge_record = battery_record.copy()
+            discharge_record["facility_code"] = battery_map.discharge_unit
+            all_records.append(discharge_record)
+
+    models = []
+
+    for record_data in all_records:
+        try:
+            models.append(FacilityScadaSchema(**record_data))
+        except ValidationError as e:
+            logger.error(f"Validation error: {e}")
+            continue
+
+    return models
+
+
 async def wemde_parse_trading_price(url: str) -> list[BalancingSummarySchema]:
     """Parse WEMDE trading price"""
 

--- a/opennem/crawl.py
+++ b/opennem/crawl.py
@@ -45,7 +45,12 @@ from opennem.crawlers.nemweb import (
     AEMONNemwebDispatchScadaArchive,
 )
 from opennem.crawlers.wem import WEMBalancing, WEMBalancingLive, WEMFacilityScada, WEMFacilityScadaLive
-from opennem.crawlers.wemde import AEMOWEMDEFacilityScadaHistory, AEMOWEMDETradingReport, AEMOWEMDETradingReportHistory
+from opennem.crawlers.wemde import (
+    AEMOWEMDEDispatch,
+    AEMOWEMDEFacilityScadaHistory,
+    AEMOWEMDETradingReport,
+    AEMOWEMDETradingReportHistory,
+)
 from opennem.schema.date_range import CrawlDateRange
 from opennem.utils.dates import get_today_opennem
 from opennem.utils.modules import load_all_crawler_definitions
@@ -95,6 +100,7 @@ async def load_crawlers(live_load: bool = False) -> CrawlerSet:
         WEMFacilityScada,
         WEMFacilityScadaLive,
         # WEMDE
+        AEMOWEMDEDispatch,
         AEMOWEMDEFacilityScadaHistory,
         AEMOWEMDETradingReport,
         AEMOWEMDETradingReportHistory,

--- a/opennem/crawlers/wemde.py
+++ b/opennem/crawlers/wemde.py
@@ -5,7 +5,7 @@ import logging
 from datetime import datetime
 from typing import Any
 
-from opennem.clients.wemde import wemde_parse_facilityscada, wemde_parse_trading_price
+from opennem.clients.wemde import wemde_parse_dispatch, wemde_parse_facilityscada, wemde_parse_trading_price
 from opennem.controllers.nem import ControllerReturn
 from opennem.core.crawlers.meta import CrawlStatTypes, crawler_get_meta, crawler_set_meta_many
 from opennem.core.crawlers.schema import CrawlerDefinition, CrawlerPriority, CrawlerSchedule
@@ -106,6 +106,18 @@ async def run_wemde_crawl(
             logger.error(f"Error parsing data with {crawler.parser}: {e}")
             continue
 
+    # de-duplicate on the upsert key — overlapping dispatch files repeat intervals,
+    # which a single ON CONFLICT batch rejects. Entries are newest-first, so keeping
+    # the first occurrence keeps the freshest dispatch solution per interval.
+    deduped: dict[tuple, FacilityScadaSchema | BalancingSummarySchema] = {}
+    for record in data:
+        if isinstance(record, BalancingSummarySchema):
+            key = (record.interval, record.network_id, record.network_region, record.is_forecast)
+        else:
+            key = (record.interval, record.network_id, record.facility_code, record.is_forecast)
+        deduped.setdefault(key, record)
+    data = list(deduped.values())
+
     # persist data
     update_fields = ["generated", "energy"]
 
@@ -157,6 +169,7 @@ async def run_wemde_crawl_from_url(urls: list[str]) -> None:
 async def run_all_wem_crawlers(latest: bool = True, limit: int | None = None) -> None:
     for crawler in [
         AEMOWEMDEFacilityScada,
+        AEMOWEMDEDispatch,
         AEMOWEMDETradingReport,
         AEMOWEMDEFacilityScadaHistory,
         AEMOWEMDETradingReportHistory,
@@ -193,6 +206,21 @@ AEMOWEMDEFacilityScada = CrawlerDefinition(
     archive_version=AEMOWEMDEFacilityScadaHistory,
 )
 
+AEMOWEMDEDispatch = CrawlerDefinition(
+    bucket_size=AEMODataBucketSize.day,
+    contains_days=1,
+    priority=CrawlerPriority.high,
+    schedule=CrawlerSchedule.live,
+    # most-recent files only — each file carries a rolling ~2h window of intervals,
+    # so a few of them fully cover recent dispatch without re-downloading the folder
+    limit=3,
+    name="au.wemde.current.dispatch",
+    url="https://data.wa.aemo.com.au/public/market-data/wemde/dispatchSolution/dispatchData/current/",
+    network=NetworkWEM,
+    processor=run_wemde_crawl,
+    parser=wemde_parse_dispatch,
+)
+
 AEMOWEMDETradingReportHistory = CrawlerDefinition(
     bucket_size=AEMODataBucketSize.day,
     contains_days=365,
@@ -218,7 +246,7 @@ AEMOWEMDETradingReport = CrawlerDefinition(
     archive_version=AEMOWEMDETradingReportHistory,
 )
 
-ALL_WEM_CRAWLERS = [AEMOWEMDEFacilityScada, AEMOWEMDETradingReport, APVIRooftopMonthCrawler]
+ALL_WEM_CRAWLERS = [AEMOWEMDEFacilityScada, AEMOWEMDEDispatch, AEMOWEMDETradingReport, APVIRooftopMonthCrawler]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Implements #527.

Ingests AEMO's WEMDE `dispatchSolution/dispatchData` `current/` feed — 5-min cleared dispatch quantities published ~5 min behind real time, vs the `facilityScada` feed's ~24h lag.

## Changes

- **`wemde_parse_dispatch`** (`clients/wemde.py`) — parses the `energy` market schedule, `quantity` (MW) → `generated`, `energy = quantity/12`. Reuses the existing battery charge/discharge split logic.
- **`au.wemde.current.dispatch`** crawler — `live` schedule, `limit=3` (each file carries a rolling ~2h window, so the 3 most-recent files cover recent dispatch without re-downloading the folder).
- **dedup in `run_wemde_crawl`** — overlapping dispatch files repeat intervals; a single `ON CONFLICT` batch rejects duplicate keys, so records are de-duped on the upsert key (newest file wins).

## Verified on dev

Crawler run persisted 2,231 WEM records to dev `facility_scada`. `COLLIE_ESR1` charging at -150 MW split correctly into `COLLIE_ESRL1`, `energy = generated/12`, AWST-naive timestamps. `COLLIE_ESR4`/`ESR5` read 0 — confirmed genuinely idle in the dispatch feed too (the original issue).

## Follow-ups (not in this PR)

- **Overwrite gating** — dispatch is the only live WEM writer so it wins for live data, but the `facilityScada` history crawler will overwrite intervals ~24-48h later when its daily files publish. To fully honour "dispatch always wins" the `facilityScada` path needs a gate. Tracked in #527.
- **Backfill** — the `previous/` daily archives (~300MB zips, 288×24MB JSON) need a memory-safe streaming parser; not wired up here.