### PR TITLE
fix(crawler): WEM dispatch — keep only the binding interval

### DIFF
--- a/opennem/clients/wemde.py
+++ b/opennem/clients/wemde.py
@@ -147,6 +147,10 @@ async def wemde_parse_dispatch(url: str) -> list[FacilityScadaSchema]:
     Uses the cleared `energy` market dispatch quantity (MW) per facility as the WEM
     generation signal. Dispatch solutions publish as 5-min files ~5 min behind real
     time — vs the facilityScada feed's ~24h lag. `quantity` is MW (negative = charging).
+
+    Only the binding interval (`primaryDispatchInterval`) is kept — `solutionData`
+    also carries ~2h of forward look-ahead dispatch, which is a projection, not an
+    actual, and would otherwise land in facility_scada as future-dated rows.
     """
 
     download_jsons = await _wemde_download_dataset(url)
@@ -161,7 +165,13 @@ async def wemde_parse_dispatch(url: str) -> list[FacilityScadaSchema]:
     battery_records: list[dict] = []
 
     for download_json in download_jsons:
+        primary_interval = download_json.get("primaryDispatchInterval")
+
         for interval_entry in download_json.get("solutionData", []):
+            # skip the forward look-ahead intervals — keep only the binding interval
+            if interval_entry.get("dispatchInterval") != primary_interval:
+                continue
+
             interval = datetime.fromisoformat(interval_entry["dispatchInterval"]).replace(tzinfo=None)
 
             energy_schedule = next(

--- a/opennem/crawlers/wemde.py
+++ b/opennem/crawlers/wemde.py
@@ -211,9 +211,9 @@ AEMOWEMDEDispatch = CrawlerDefinition(
     contains_days=1,
     priority=CrawlerPriority.high,
     schedule=CrawlerSchedule.live,
-    # most-recent files only — each file carries a rolling ~2h window of intervals,
-    # so a few of them fully cover recent dispatch without re-downloading the folder
-    limit=3,
+    # most-recent files only — each file yields one binding interval, so 6 covers
+    # the last ~30 min of dispatch and tolerates a short crawler outage
+    limit=6,
     name="au.wemde.current.dispatch",
     url="https://data.wa.aemo.com.au/public/market-data/wemde/dispatchSolution/dispatchData/current/",
     network=NetworkWEM,


### PR DESCRIPTION
Follow-up to #530 (Refs #527).

The WEMDE dispatch `solutionData` array carries the binding `primaryDispatchInterval` **plus ~2h of forward look-ahead dispatch** (file `_1050` spans 10:50 → 12:45). The initial parser wrote all 24 intervals, so `facility_scada` for WEM was getting ~2h of *projected* dispatch stored as actuals — `max(interval)` sat ~2h in the future.

## Fix

- `wemde_parse_dispatch` filters `solutionData` to `dispatchInterval == primaryDispatchInterval` — the binding interval only.
- Crawler `limit` 3 → 6: each file now yields one interval, so 6 covers a ~30 min rolling window and tolerates a short crawler outage.

## Verified on dev

Crawl run persisted 510 records, `Latest interval: 2026-05-22 10:55:00` — ~4 min behind real time (vs 2h *ahead* before the fix). Gaps older than the rolling window are still backfilled by the `facilityScada` history crawler.