### PR TITLE
feat(tasks): task_wem_interval_check — 5-min WEM dispatch + aggregates

### DIFF
--- a/opennem/tasks/app.py
+++ b/opennem/tasks/app.py
@@ -62,6 +62,7 @@ from opennem.tasks.tasks import (
     task_weekly_summary_nem,
     task_weekly_summary_wem,
     task_wem_day_crawl,
+    task_wem_interval_check,
 )
 from opennem.utils.host import get_hostname
 from opennem.utils.sentry import setup_sentry
@@ -151,6 +152,14 @@ class WorkerSettings:
             minute={30},
             second=58,
             timeout=None,
+            unique=True,
+        ),
+        # WEM near-real-time dispatch feed + aggregates — every 5 min
+        cron(
+            task_wem_interval_check,
+            minute=set(range(0, 60, 5)),
+            second=50,
+            timeout=270,
             unique=True,
         ),
         # APVI Rooftop

--- a/opennem/tasks/tasks.py
+++ b/opennem/tasks/tasks.py
@@ -28,7 +28,7 @@ from opennem.crawlers.nemweb import (
     AEMONemwebTradingIS,
     AEMONNemwebDispatchScada,
 )
-from opennem.crawlers.wemde import run_all_wem_crawlers
+from opennem.crawlers.wemde import AEMOWEMDEDispatch, run_all_wem_crawlers, run_wemde_crawl
 from opennem.db import get_write_session
 from opennem.db.clickhouse.schema import optimize_clickhouse_tables
 from opennem.exporter.facilities import export_facilities_static
@@ -128,6 +128,28 @@ async def task_wem_day_crawl(ctx) -> None:
 
     await run_export_power_latest_for_network(network=NetworkWEM)
     await run_export_energy_for_year(network=NetworkWEM)
+
+
+async def task_wem_interval_check(ctx) -> None:
+    """Every 5 min: crawl the WEMDE dispatch feed and run the WEM aggregates.
+
+    Near-real-time WEM via the dispatch-solution feed (~5-10 min lag). The hourly
+    task_wem_day_crawl remains the full catch-up pass (all WEM crawlers, 2-day window).
+    """
+    await run_wemde_crawl(AEMOWEMDEDispatch, latest=True, limit=AEMOWEMDEDispatch.limit)
+
+    # aggregate WEM facility_scada -> CH unit_intervals over a recent window
+    end_date = get_last_completed_interval_for_network(network=NetworkNEM)
+    start_date = end_date - timedelta(hours=6)
+    async with get_write_session() as session:
+        await process_unit_intervals_backlog(
+            session=session,
+            start_date=start_date,
+            end_date=end_date,
+            network=NetworkWEM,
+        )
+
+    await run_export_power_latest_for_network(network=NetworkWEM)
 
 
 async def task_apvi_crawl(ctx) -> None:


### PR DESCRIPTION
Follow-up to #530 / #531 (Refs #527).

`au.wemde.current.dispatch` was only running via the hourly `task_wem_day_crawl` cron (HH:30) — so WEM went from 24h stale to ~1h stale, not the ~5-min freshness the dispatch feed actually allows.

## Change

New ARQ cron **`task_wem_interval_check`**, every 5 min — mirrors `task_nem_interval_check`:

1. Crawls the WEMDE dispatch feed (`au.wemde.current.dispatch`)
2. Aggregates WEM `facility_scada` → CH `unit_intervals` over a 6h window
3. Runs the WEM power export

`task_wem_day_crawl` stays as the hourly full catch-up (all WEM crawlers, 2-day aggregate window, yearly energy export).

## Verified on dev

Ran `task_wem_interval_check` against dev end-to-end — crawl, aggregate, export all succeeded. CH `unit_intervals` energy matches PG `facility_scada` exactly, per interval:

| interval | PG gen/energy | CH (FINAL) gen/energy |
|---|---|---|
| 11:35 | 1596.6 / 133.05 | 1596.6 / 133.05 |
| 11:30 | 1574.3 / 131.19 | 1574.3 / 131.19 |
| 11:25 | 1591.7 / 132.64 | 1591.7 / 132.64 |

Data fresh to the current interval. (CH unit count is ~4 lower — pre-existing zero-generation WEM codes with no `units` row; no energy impact.)