### PR TITLE
fix(api): gapfill stats_factory series onto interval grid

### DIFF
--- a/opennem/api/stats/controllers.py
+++ b/opennem/api/stats/controllers.py
@@ -79,6 +79,35 @@ def stats_factory(
 
         data_sorted = OrderedDict(sorted(data_grouped.items()))
 
+        # Gapfill: reindex onto a complete interval grid so history.data stays
+        # contiguous between start and last. Consumers reconstruct each point's
+        # time as start + i*interval, so missing intervals must be explicit
+        # nulls — absent rows misalign everything after a gap (issue #534).
+        # Fixed-duration intervals only; month/year stepping is not uniform.
+        grid_step = {
+            "5 minutes": timedelta(minutes=5),
+            "30 minutes": timedelta(minutes=30),
+            "1 hour": timedelta(hours=1),
+            "1 day": timedelta(days=1),
+        }.get(interval.interval_sql)
+
+        if grid_step and len(data_sorted) > 1:
+            grid_keys = list(data_sorted.keys())
+            filled: OrderedDict[datetime, Any] = OrderedDict()
+            cursor, grid_end = grid_keys[0], grid_keys[-1]
+            while cursor <= grid_end:
+                filled[cursor] = data_sorted.get(cursor)
+                cursor += grid_step
+
+            # only adopt the grid if it preserves every original interval —
+            # otherwise the source isn't aligned to the step and we'd drop data
+            if all(k in filled for k in grid_keys):
+                data_sorted = filled
+            else:
+                logger.warning(
+                    f"stats_factory: skipping gapfill for {group_code} — intervals not aligned to {interval.interval_sql} grid"
+                )
+
         data_value = list(data_sorted.values())
 
         # Skip null series


### PR DESCRIPTION
fixes #534

power/energy exports built `history.data` straight from the rows the query returned. when source data has a gap, the array ends up shorter than the `start`->`last` span implies — and consumers reconstruct each point's time as `start + i*interval`, so everything after a gap plots too early and the tail goes blank.

visible on the wem 7d feed: recent ~24-48h missing. also affects prod `au.wem.demand` and `battery_charging` (genuinely sparse series).

fix: in `stats_factory`, reindex each series onto a complete interval grid (min..max at the interval step), inserting nulls for missing intervals. fixed-duration intervals only (5m/30m/1h/1d) — month/year skipped. contiguous series are unchanged (grid == existing keys); if intervals aren't aligned to the step it logs and skips rather than dropping data.

verified against dev wem 7d — every series now has `last == start + (n-1)*interval` (gap_h 0.0), with the real ~25h dev data hole now represented as explicit interior nulls instead of a misaligned tail.