### PR TITLE
fix(catchup): wemde dispatch bucket size + MV backfill

### DIFF
--- a/opennem/crawlers/wemde.py
+++ b/opennem/crawlers/wemde.py
@@ -207,7 +207,11 @@ AEMOWEMDEFacilityScada = CrawlerDefinition(
 )
 
 AEMOWEMDEDispatch = CrawlerDefinition(
-    bucket_size=AEMODataBucketSize.day,
+    # each file is one 5-min dispatch interval — bucket as `interval` so
+    # `_get_limit_for_crawler(days)` returns days*12*24 and catchup actually
+    # spans the gap window. With `day` it returned `days` files (~30 min),
+    # so any outage longer than a few minutes was unrecoverable. (#534-followup)
+    bucket_size=AEMODataBucketSize.interval,
     contains_days=1,
     priority=CrawlerPriority.high,
     schedule=CrawlerSchedule.live,

--- a/opennem/workers/catchup.py
+++ b/opennem/workers/catchup.py
@@ -309,6 +309,15 @@ async def catchup_last_days(days: int = 1, network: NetworkSchema | None = None,
     await run_unit_intervals_aggregate_for_last_days(days=days)
     await run_market_summary_aggregate_for_last_days(days=days)
 
+    # backfill MVs over the same window — auto-population leaves partial
+    # aggregates after a gap, so re-aggregating unit_intervals isn't enough
+    # to repopulate fueltech_intervals_mv et al on its own (#534-followup)
+    from opennem.db.clickhouse.materialized_views import backfill_materialized_views
+
+    mv_end = datetime.now(ZoneInfo("Australia/Brisbane")).replace(tzinfo=None, microsecond=0)
+    mv_start = mv_end - timedelta(days=days + 1)
+    await asyncio.to_thread(backfill_materialized_views, start_date=mv_start, end_date=mv_end, refresh_views=False)
+
     # run exports
     CURRENT_YEAR = datetime.now(ZoneInfo("Australia/Brisbane")).year
 


### PR DESCRIPTION
followups from the WEM gap debugging — two bugs that together made WEM gaps unrecoverable via catchup.

## 1. AEMOWEMDEDispatch.bucket_size=day → should be interval

each \`ReferenceDispatchSolution_*.json\` file is one 5-minute dispatch interval. with bucket_size=day, \`_get_limit_for_crawler(days=7)\` returned **7** (treating each file as a day) instead of 7×12×24. catchup only ever fetched the last ~7 files (≈30 min) so any outage longer than that was unrecoverable — even though the source directory holds ~80 files (~6h).

observed: dev had ~24h missing, prod just had 3h55m missing today. fetching all 83 files manually closed both holes.

## 2. catchup_last_days doesn't backfill MVs

\`catchup_last_days\` re-aggregates \`unit_intervals\` / \`market_summary\` but relies on MV auto-population. \`fueltech_intervals_mv\` (the 5-min MV the power export reads) auto-populates with partial aggregates whenever \`unit_intervals\` is touched after a gap — so the re-aggregate succeeded but the MV stayed empty for the gap window.

\`catchup_date\` already calls \`backfill_materialized_views\` after its aggregates; \`catchup_last_days\` does too now. MV backfill window matches the aggregate window (+1 day margin), AEST per the MV timezone rule.

verified on both dev and prod: with these fixes plus the existing gapfill in #535, future WEM crawler outages get caught and recovered by the regular catchup without manual intervention.