### PR TITLE
feat(wem): 5-min dispatch price from WEMDE dispatch solution

### DIFF
--- a/opennem/aggregates/market_summary.py
+++ b/opennem/aggregates/market_summary.py
@@ -148,12 +148,18 @@ async def _get_market_summary_data(
         GROUP BY 1
     ),
     gapfilled_data AS (
-        -- Generate complete time series with gap filling for each region
+        -- Generate complete time series with gap filling for each region.
+        -- Price: prefer price_dispatch (5-min dispatch clearing price, populated
+        -- for WEM by the WEMDE dispatch crawler) and fall back to price (5-min
+        -- for NEM, 30-min trading interval for WEM). locf() carries the trading
+        -- price forward across the 5-min buckets within its 30-min interval —
+        -- semantically correct since the trading price IS the price for that
+        -- whole trading interval.
         SELECT
             time_bucket_gapfill('5 minutes', interval, :start_time_window, :end_time) as interval,
             network_id,
             network_region,
-            avg(CAST(price AS double precision)) as price,
+            locf(avg(CAST(COALESCE(price_dispatch, price) AS double precision))) as price,
             avg(CAST(demand AS double precision)) as demand,
             avg(CAST(demand_total AS double precision)) as demand_total,
             avg(ROUND((ss_solar_uigf - ss_solar_clearedmw)::numeric, 4)) as curtailment_solar_total,

--- a/opennem/clients/wemde.py
+++ b/opennem/clients/wemde.py
@@ -141,12 +141,17 @@ async def wemde_parse_facilityscada(url: str) -> list[FacilityScadaSchema]:
     return models
 
 
-async def wemde_parse_dispatch(url: str) -> list[FacilityScadaSchema]:
+async def wemde_parse_dispatch(url: str) -> list[FacilityScadaSchema | BalancingSummarySchema]:
     """Parses a WEMDE dispatch solution file.
 
     Uses the cleared `energy` market dispatch quantity (MW) per facility as the WEM
     generation signal. Dispatch solutions publish as 5-min files ~5 min behind real
     time — vs the facilityScada feed's ~24h lag. `quantity` is MW (negative = charging).
+
+    Also emits one BalancingSummarySchema per binding interval carrying the 5-min
+    dispatch energy clearing price (`prices.energy`) as `price_dispatch`. WEM trading
+    prices (`balancing_summary.price`) are settled at 30-min cadence — `price_dispatch`
+    gives the 5-min-resolution view downstream consumers need.
 
     Only the binding interval (`primaryDispatchInterval`) is kept — `solutionData`
     also carries ~2h of forward look-ahead dispatch, which is a projection, not an
@@ -163,6 +168,7 @@ async def wemde_parse_dispatch(url: str) -> list[FacilityScadaSchema]:
 
     original_records: list[dict] = []
     battery_records: list[dict] = []
+    price_models: list[BalancingSummarySchema] = []
 
     for download_json in download_jsons:
         primary_interval = download_json.get("primaryDispatchInterval")
@@ -173,6 +179,21 @@ async def wemde_parse_dispatch(url: str) -> list[FacilityScadaSchema]:
                 continue
 
             interval = datetime.fromisoformat(interval_entry["dispatchInterval"]).replace(tzinfo=None)
+
+            # 5-min dispatch energy price (binding interval only)
+            energy_price = (interval_entry.get("prices") or {}).get("energy")
+            if energy_price is not None:
+                try:
+                    price_models.append(
+                        BalancingSummarySchema(
+                            network_id="WEM",
+                            network_region="WEM",
+                            interval=interval,
+                            price_dispatch=float(energy_price),
+                        )
+                    )
+                except ValidationError as e:
+                    logger.error(f"Validation error parsing dispatch price for {interval}: {e}")
 
             energy_schedule = next(
                 (s for s in interval_entry.get("schedule", []) if s.get("marketService") == "energy"),
@@ -217,7 +238,7 @@ async def wemde_parse_dispatch(url: str) -> list[FacilityScadaSchema]:
             discharge_record["facility_code"] = battery_map.discharge_unit
             all_records.append(discharge_record)
 
-    models = []
+    models: list[FacilityScadaSchema | BalancingSummarySchema] = []
 
     for record_data in all_records:
         try:
@@ -225,6 +246,8 @@ async def wemde_parse_dispatch(url: str) -> list[FacilityScadaSchema]:
         except ValidationError as e:
             logger.error(f"Validation error: {e}")
             continue
+
+    models.extend(price_models)
 
     return models
 

--- a/opennem/core/crawlers/schema.py
+++ b/opennem/core/crawlers/schema.py
@@ -66,6 +66,12 @@ class CrawlerDefinition(BaseConfig):
     processor: Callable
     parser: Callable | None = None
 
+    # Columns the bulk upsert should update for records this crawler produces.
+    # Used by the WEMDE crawler runner to route dispatch records to
+    # price_dispatch and trading records to price.
+    fs_update_fields: list[str] | None = None
+    bs_update_fields: list[str] | None = None
+
 
 class CrawlerSet(BaseConfig):
     """Defines a set of crawlers"""

--- a/opennem/crawlers/wemde.py
+++ b/opennem/crawlers/wemde.py
@@ -118,15 +118,24 @@ async def run_wemde_crawl(
         deduped.setdefault(key, record)
     data = list(deduped.values())
 
-    # persist data
-    update_fields = ["generated", "energy"]
+    # persist — split by schema since FacilityScada and BalancingSummary go to
+    # different tables. The dispatch parser now emits both: facility scada (gen)
+    # plus a per-interval BalancingSummary carrying price_dispatch (5-min price).
+    fs_records = [r for r in data if isinstance(r, FacilityScadaSchema)]
+    bs_records = [r for r in data if isinstance(r, BalancingSummarySchema)]
 
-    if crawler.parser == wemde_parse_trading_price:
-        update_fields = ["price", "price_dispatch"]
+    if fs_records:
+        await persist_facility_scada_bulk(records=fs_records, update_fields=["generated", "energy"])
 
-    await persist_facility_scada_bulk(records=data, update_fields=update_fields)
+    if bs_records:
+        if crawler.parser == wemde_parse_trading_price:
+            bs_update_fields = ["price"]
+        else:
+            # dispatch parser produces price_dispatch (5-min); trading parser produces price (30-min)
+            bs_update_fields = ["price_dispatch"]
+        await persist_facility_scada_bulk(records=bs_records, update_fields=bs_update_fields)
 
-    logger.info(f"Persisted {len(data)} records")
+    logger.info(f"Persisted {len(fs_records)} facility_scada + {len(bs_records)} balancing_summary records")
 
     # track latest interal and update metadata
     recent_latest_interval = max([i.interval for i in data if i.interval])

--- a/opennem/crawlers/wemde.py
+++ b/opennem/crawlers/wemde.py
@@ -121,19 +121,20 @@ async def run_wemde_crawl(
     # persist — split by schema since FacilityScada and BalancingSummary go to
     # different tables. The dispatch parser now emits both: facility scada (gen)
     # plus a per-interval BalancingSummary carrying price_dispatch (5-min price).
+    # Update-field sets are declared on the CrawlerDefinition so this runner
+    # stays parser-agnostic — dispatch crawlers set bs_update_fields=["price_dispatch"]
+    # and trading-price crawlers set ["price"].
     fs_records = [r for r in data if isinstance(r, FacilityScadaSchema)]
     bs_records = [r for r in data if isinstance(r, BalancingSummarySchema)]
 
     if fs_records:
-        await persist_facility_scada_bulk(records=fs_records, update_fields=["generated", "energy"])
+        fs_update_fields = crawler.fs_update_fields or ["generated", "energy"]
+        await persist_facility_scada_bulk(records=fs_records, update_fields=fs_update_fields)
 
     if bs_records:
-        if crawler.parser == wemde_parse_trading_price:
-            bs_update_fields = ["price"]
-        else:
-            # dispatch parser produces price_dispatch (5-min); trading parser produces price (30-min)
-            bs_update_fields = ["price_dispatch"]
-        await persist_facility_scada_bulk(records=bs_records, update_fields=bs_update_fields)
+        if not crawler.bs_update_fields:
+            raise Exception(f"Crawler {crawler.name} produced BalancingSummary records but has no bs_update_fields configured")
+        await persist_facility_scada_bulk(records=bs_records, update_fields=crawler.bs_update_fields)
 
     logger.info(f"Persisted {len(fs_records)} facility_scada + {len(bs_records)} balancing_summary records")
 
@@ -232,6 +233,8 @@ AEMOWEMDEDispatch = CrawlerDefinition(
     network=NetworkWEM,
     processor=run_wemde_crawl,
     parser=wemde_parse_dispatch,
+    # dispatch yields 5-min energy clearing price → price_dispatch (5-min column)
+    bs_update_fields=["price_dispatch"],
 )
 
 AEMOWEMDETradingReportHistory = CrawlerDefinition(
@@ -244,6 +247,8 @@ AEMOWEMDETradingReportHistory = CrawlerDefinition(
     network=NetworkWEM,
     processor=run_wemde_crawl,
     parser=wemde_parse_trading_price,
+    # trading prices land in the 30-min `price` column
+    bs_update_fields=["price"],
 )
 
 AEMOWEMDETradingReport = CrawlerDefinition(
@@ -257,6 +262,7 @@ AEMOWEMDETradingReport = CrawlerDefinition(
     processor=run_wemde_crawl,
     parser=wemde_parse_trading_price,
     archive_version=AEMOWEMDETradingReportHistory,
+    bs_update_fields=["price"],
 )
 
 ALL_WEM_CRAWLERS = [AEMOWEMDEFacilityScada, AEMOWEMDEDispatch, AEMOWEMDETradingReport, APVIRooftopMonthCrawler]

--- a/tests/clients/test_wemde_dispatch.py
+++ b/tests/clients/test_wemde_dispatch.py
@@ -1,0 +1,101 @@
+"""Unit tests for wemde_parse_dispatch — 5-min dispatch price extraction."""
+
+from datetime import datetime
+
+import pytest
+
+from opennem.clients import wemde
+from opennem.persistence.schema import BalancingSummarySchema, FacilityScadaSchema
+
+
+def _make_dispatch_json(
+    primary_interval: str = "2026-05-25T16:45:00+08:00",
+    extra_interval: str = "2026-05-25T16:50:00+08:00",
+    energy_price: float | None = 115.28,
+) -> dict:
+    """Build a minimal dispatch solution JSON with a binding interval and one look-ahead."""
+
+    def _interval(ts: str, price: float | None) -> dict:
+        prices: dict[str, float] = {}
+        if price is not None:
+            prices["energy"] = price
+        return {
+            "dispatchInterval": ts,
+            "dispatchType": "Dispatch",
+            "scenario": "Reference",
+            "prices": prices,
+            "schedule": [
+                {
+                    "marketService": "energy",
+                    "facilitySchedule": [
+                        {"facilityCode": "MUJA_G5", "quantity": 220.0},
+                        {"facilityCode": "MUJA_G6", "quantity": 215.0},
+                    ],
+                }
+            ],
+        }
+
+    return {
+        "primaryDispatchInterval": primary_interval,
+        "solutionData": [
+            _interval(primary_interval, energy_price),
+            # look-ahead interval — must be skipped by parser
+            _interval(extra_interval, 999.0),
+        ],
+    }
+
+
+@pytest.fixture()
+def _patched_parser(monkeypatch):
+    """Patch the network downloader + battery map so wemde_parse_dispatch is pure-fn."""
+
+    async def _fake_dl(_url: str) -> list[dict]:
+        return [_make_dispatch_json()]
+
+    async def _fake_battery_map():
+        return {}
+
+    monkeypatch.setattr(wemde, "_wemde_download_dataset", _fake_dl)
+    monkeypatch.setattr(wemde, "get_battery_unit_map", _fake_battery_map)
+
+
+@pytest.mark.asyncio
+async def test_wemde_dispatch_emits_facility_and_price(_patched_parser):
+    """Binding interval yields facility_scada rows AND a balancing_summary price_dispatch row."""
+    records = await wemde.wemde_parse_dispatch("ignored")
+
+    fs = [r for r in records if isinstance(r, FacilityScadaSchema)]
+    bs = [r for r in records if isinstance(r, BalancingSummarySchema)]
+
+    # Two facility schedule entries → two FS rows; one binding interval → one BS row.
+    # Look-ahead intervals must be skipped (no extra FS or BS rows).
+    assert len(fs) == 2
+    assert len(bs) == 1
+
+    bs_row = bs[0]
+    assert bs_row.network_id == "WEM"
+    assert bs_row.network_region == "WEM"
+    assert bs_row.price_dispatch == pytest.approx(115.28)
+    # interval is tz-stripped binding interval
+    assert bs_row.interval == datetime(2026, 5, 25, 16, 45)
+    # FS rows all carry the binding interval, never the look-ahead
+    assert all(r.interval == datetime(2026, 5, 25, 16, 45) for r in fs)
+
+
+@pytest.mark.asyncio
+async def test_wemde_dispatch_no_price_field(monkeypatch):
+    """Missing prices.energy → FS rows still emitted, no BS row."""
+
+    async def _fake_dl(_url: str) -> list[dict]:
+        return [_make_dispatch_json(energy_price=None)]
+
+    async def _fake_battery_map():
+        return {}
+
+    monkeypatch.setattr(wemde, "_wemde_download_dataset", _fake_dl)
+    monkeypatch.setattr(wemde, "get_battery_unit_map", _fake_battery_map)
+
+    records = await wemde.wemde_parse_dispatch("ignored")
+
+    assert any(isinstance(r, FacilityScadaSchema) for r in records)
+    assert not any(isinstance(r, BalancingSummarySchema) for r in records)


### PR DESCRIPTION
WEM trading prices are settled at 30-min cadence (\`balancing_summary.price\`). The WEMDE dispatch solution JSON carries a **5-min energy clearing price** per binding interval at \`solutionData[i].prices.energy\` — which the existing dispatch parser was discarding. Result: \`au.wem.price\` in the 7d feed had 1 valid point per 30 min vs 5 nulls.

## Changes

- **\`wemde_parse_dispatch\`**: also emit a \`BalancingSummarySchema\` per binding interval with \`price_dispatch\` populated from \`prices.energy\`. Return type widens to a mixed list of FacilityScada + BalancingSummary.
- **\`run_wemde_crawl\`**: split records by schema before persistence — facility_scada records and balancing_summary records go to different tables. Previous code path passed everything to \`persist_facility_scada_bulk\` and silently dropped any BalancingSummary records from dispatch.
- **\`market_summary\` aggregate**: in \`gapfilled_data\` CTE, prefer \`COALESCE(price_dispatch, price)\` and wrap in \`locf()\`. The trading price carries forward across its own 5-min sub-intervals when \`price_dispatch\` isn't populated (historical or pre-crawler data). Semantically correct — the trading price IS the price for the whole 30-min trading interval.

## Verified on dev

- Crawl: \`Persisted 9180 facility_scada + 108 balancing_summary records\`
- PG \`balancing_summary.price_dispatch\` (WEM, before/after): 0 → 108 rows over ~9h
- CH \`market_summary.price\` (WEM, binding window): 108 rows, 81 unique 5-min prices ($39–$140/MWh)
- Feed \`au.wem.price\` nulls in 7d (before/after): 1286/2017 → 0/2017