### PR TITLE
docs(sdk): update typescript reference for 0.9.0

### DIFF
--- a/docs/sdk/typescript/reference.mdx
+++ b/docs/sdk/typescript/reference.mdx
@@ -79,7 +79,7 @@ async getFacilityData(
 - `params`: Optional parameters:
   - `interval`: Time interval
   - `dateStart` / `dateEnd`: Timezone-naive dates in network time
-  - `unitCodes`: Single unit code or array — narrow to specific units within the facilities
+  - `unitCodes`: Single unit code or array, narrows to specific units within the facilities
 
 **Example:**
 ```typescript

--- a/docs/sdk/typescript/reference.mdx
+++ b/docs/sdk/typescript/reference.mdx
@@ -38,8 +38,11 @@ async getNetworkData(
   - `interval`: Time interval (e.g., "5m", "1h", "1d")
   - `dateStart`: Start date (timezone-naive)
   - `dateEnd`: End date (timezone-naive)
-  - `primaryGrouping`: Primary grouping field
-  - `secondaryGrouping`: Secondary grouping field
+  - `primaryGrouping`: Primary grouping field (`"network"` or `"network_region"`)
+  - `secondaryGrouping`: Array of secondary grouping fields (`"fueltech"`, `"fueltech_group"`, `"status"`, `"renewable"`)
+  - `network_region`: Filter to a specific region (e.g., `"NSW1"`)
+  - `fueltech`: Array of `UnitFueltechType` to filter by
+  - `fueltech_group`: Array of `UnitFueltechGroupType` to filter by
 
 **Example:**
 ```typescript
@@ -48,7 +51,7 @@ const { datatable } = await client.getNetworkData("NEM", ["energy"], {
   dateStart: "2024-01-01T00:00:00",
   dateEnd: "2024-01-02T00:00:00",
   primaryGrouping: "network_region",
-  secondaryGrouping: "fueltech"
+  secondaryGrouping: ["fueltech"]
 })
 ```
 
@@ -73,7 +76,10 @@ async getFacilityData(
 - `networkCode`: The network containing the facilities
 - `facilityCodes`: Single facility code or array of codes
 - `metrics`: Array of metrics to fetch
-- `params`: Optional parameters (similar to getNetworkData)
+- `params`: Optional parameters:
+  - `interval`: Time interval
+  - `dateStart` / `dateEnd`: Timezone-naive dates in network time
+  - `unitCodes`: Single unit code or array — narrow to specific units within the facilities
 
 **Example:**
 ```typescript
@@ -108,10 +114,15 @@ async getMarket(
 **Parameters:**
 - `networkCode`: The market to fetch data for
 - `metrics`: Array of market metrics including:
-  - Price and demand: `"price"`, `"demand"`, `"demand_energy"`
+  - Price and demand: `"price"`, `"demand"`, `"demand_energy"`, `"demand_gross"`, `"demand_gross_energy"`
+  - Renewable generation: `"generation_renewable"`, `"generation_renewable_with_storage"`, `"renewable_proportion"`, `"renewable_with_storage_proportion"` (and their `_energy` variants)
   - Curtailment power (MW): `"curtailment"`, `"curtailment_solar_utility"`, `"curtailment_wind"`
   - Curtailment energy (MWh): `"curtailment_energy"`, `"curtailment_solar_utility_energy"`, `"curtailment_wind_energy"`
-- `params`: Optional parameters (similar to getNetworkData)
+  - Flows: `"flow_imports"`, `"flow_exports"` (and their `_energy` variants)
+- `params`: Optional parameters:
+  - `interval`, `dateStart`, `dateEnd`
+  - `primaryGrouping`: `"network"` or `"network_region"`
+  - `network_region`: Filter to a specific region (e.g., `"NSW1"`)
 
 **Example - Price and Demand:**
 ```typescript
@@ -178,9 +189,61 @@ async getFacilities(
 ```typescript
 const { table } = await client.getFacilities({
   status_id: ["operating"],
-  fueltech_id: ["solar", "wind"],
+  fueltech_id: ["solar_utility", "wind"],
   network_id: "NEM"
 })
+```
+
+# Pollution Data
+
+## getFacilityPollution
+
+Fetches the endpoint at `/v4/pollution/facilities`.
+
+Get time-series pollution data from the National Pollutant Inventory for facilities with NPI tracking.
+
+```typescript
+async getFacilityPollution(
+  params?: IFacilityPollutionParams
+): Promise<ITimeSeriesResponse>
+```
+
+**Parameters:**
+- `params`: Optional filters:
+  - `facility_code`: Array of facility codes
+  - `pollutant_code`: Array of `PollutantCode` values (`"nox"`, `"so2"`, `"co"`, etc.)
+  - `pollutant_category`: Array of `PollutantCategory` values (`"air_pollutant"`, `"heavy_metal"`, etc.)
+  - `dateStart` / `dateEnd`: Timezone-naive dates
+
+When the response contains no rows, `datatable` is `undefined`.
+
+**Example:**
+```typescript
+const { response, datatable } = await client.getFacilityPollution({
+  facility_code: ["ERARING"],
+  pollutant_code: ["nox", "so2"],
+})
+```
+
+# Metrics Discovery
+
+## getAvailableMetrics
+
+Fetches the endpoint at `/v4/metrics`.
+
+Discover which metrics the API supports along with their units, descriptions, default aggregations, and which endpoints they are valid for.
+
+```typescript
+async getAvailableMetrics(): Promise<IMetricsResponse>
+```
+
+Errors are surfaced as `OpenElectricityError` (404 → `NoDataFound`, 403 → permission-denied).
+
+**Example:**
+```typescript
+const { metrics, endpoints } = await client.getAvailableMetrics()
+console.log(endpoints.data)        // metrics valid on /data
+console.log(metrics.power.unit)    // "MW"
 ```
 
 # User Information
@@ -199,4 +262,7 @@ async getCurrentUser(): Promise<IAPIResponse<IUser>>
 **Example:**
 ```typescript
 const { data: user } = await client.getCurrentUser()
+console.log(user.plan)       // "COMMUNITY" | "BASIC" | "PRO" | "ENTERPRISE"
+console.log(user.roles)      // optional OpenNEMRolesType[]
+console.log(user.rate_limit) // optional number
 ```

--- a/docs/sdk/typescript/types.mdx
+++ b/docs/sdk/typescript/types.mdx
@@ -61,7 +61,7 @@ type DataMetric =
 - `energy`: Energy generated (MWh)
 - `emissions`: CO2 equivalent emissions (tCO2e)
 - `market_value`: Market value ($)
-- `pollution`: Pollutant emissions (kg) — used with the `/pollution/facilities` endpoint
+- `pollution`: Pollutant emissions (kg), used with the `/pollution/facilities` endpoint
 - `renewable_proportion`: Renewable share of generation (%)
 - `storage_battery`: Battery storage state of charge (MWh)
 
@@ -446,7 +446,7 @@ interface IAPIResponse<T> {
 }
 ```
 
-`version` and `created_at` are optional — the `/me` endpoint may omit them.
+`version` and `created_at` are optional. The `/me` endpoint may omit them.
 
 ### IValidationErrorDetail
 

--- a/docs/sdk/typescript/types.mdx
+++ b/docs/sdk/typescript/types.mdx
@@ -36,7 +36,7 @@ type DataInterval = "5m" | "1h" | "1d" | "7d" | "1M" | "3M" | "season" | "1y" | 
 - `7d`: Weekly intervals
 - `1M`: Monthly intervals
 - `3M`: Quarterly intervals
-- `season`: Seasonal intervalsanal
+- `season`: Seasonal intervals
 - `1y`: Yearly intervals
 - `fy`: Financial year intervals
 
@@ -47,13 +47,23 @@ type DataInterval = "5m" | "1h" | "1d" | "7d" | "1M" | "3M" | "season" | "1y" | 
 Metrics available for network and facility data:
 
 ```typescript
-type DataMetric = "power" | "energy" | "emissions" | "market_value"
+type DataMetric =
+  | "power"
+  | "energy"
+  | "emissions"
+  | "market_value"
+  | "pollution"
+  | "renewable_proportion"
+  | "storage_battery"
 ```
 
 - `power`: Instantaneous power output (MW)
 - `energy`: Energy generated (MWh)
 - `emissions`: CO2 equivalent emissions (tCO2e)
 - `market_value`: Market value ($)
+- `pollution`: Pollutant emissions (kg) — used with the `/pollution/facilities` endpoint
+- `renewable_proportion`: Renewable share of generation (%)
+- `storage_battery`: Battery storage state of charge (MWh)
 
 ### MarketMetric
 
@@ -126,25 +136,100 @@ Secondary grouping options for data aggregation:
 type DataSecondaryGrouping =
   | "fueltech"
   | "fueltech_group"
+  | "status"
   | "renewable"
-  | "dispatch_type"
+```
+
+## Unit Types
+
+### UnitFueltechType
+
+Fuel technologies for a unit:
+
+```typescript
+type UnitFueltechType =
+  | "battery"
+  | "battery_charging"
+  | "battery_discharging"
+  | "bioenergy_biogas"
+  | "bioenergy_biomass"
+  | "coal_black"
+  | "coal_brown"
+  | "distillate"
+  | "gas_ccgt"
+  | "gas_ocgt"
+  | "gas_recip"
+  | "gas_steam"
+  | "gas_wcmg"
+  | "hydro"
+  | "hydro_and_storage"
+  | "pumps"
+  | "solar_rooftop"
+  | "solar_thermal"
+  | "solar_utility"
+  | "nuclear"
+  | "other"
+  | "solar"
+  | "wind"
+  | "wind_offshore"
+  | "imports"
+  | "exports"
+  | "interconnector"
+  | "aggregator_vpp"
+  | "aggregator_dr"
+```
+
+A matching `FuelTech` const is exported for autocomplete (`FuelTech.SOLAR_UTILITY`, etc.).
+
+### UnitFueltechGroupType
+
+```typescript
+type UnitFueltechGroupType =
+  | "coal"
+  | "gas"
+  | "wind"
+  | "solar"
+  | "battery"
+  | "battery_charging"
+  | "battery_discharging"
+  | "hydro"
+  | "distillate"
+  | "bioenergy"
+  | "pumps"
+  | "renewable"
+  | "fossil"
+  | "other"
+```
+
+A matching `FuelTechGroup` const is exported.
+
+### UnitStatusType
+
+```typescript
+type UnitStatusType = "committed" | "operating" | "retired"
+```
+
+A matching `UnitStatus` const is exported.
+
+### UnitDispatchType
+
+```typescript
+type UnitDispatchType =
+  | "GENERATOR"
+  | "LOAD"
+  | "BIDIRECTIONAL"
+  | "INTERCONNECTOR"
+```
+
+### UnitDateSpecificity
+
+How specific a unit-related date is:
+
+```typescript
+type UnitDateSpecificity = "year" | "month" | "quarter" | "day"
 ```
 
 ## Parameter Types
-
-### INetworkTimeSeriesParams
-
-Parameters for network data queries:
-
-```typescript
-interface INetworkTimeSeriesParams {
-  interval?: DataInterval
-  dateStart?: string
-  dateEnd?: string
-  primaryGrouping?: DataPrimaryGrouping
-  secondaryGrouping?: DataSecondaryGrouping
-}
-```
 
 ### IFacilityTimeSeriesParams
 
@@ -155,6 +240,7 @@ interface IFacilityTimeSeriesParams {
   interval?: DataInterval
   dateStart?: string
   dateEnd?: string
+  unitCodes?: string | string[]
 }
 ```
 
@@ -165,6 +251,19 @@ Parameters for market data queries:
 ```typescript
 interface IMarketTimeSeriesParams extends IFacilityTimeSeriesParams {
   primaryGrouping?: DataPrimaryGrouping
+  network_region?: string
+}
+```
+
+### INetworkTimeSeriesParams
+
+Parameters for network data queries:
+
+```typescript
+interface INetworkTimeSeriesParams extends IMarketTimeSeriesParams {
+  secondaryGrouping?: DataSecondaryGrouping[]
+  fueltech?: UnitFueltechType[]
+  fueltech_group?: UnitFueltechGroupType[]
 }
 ```
 
@@ -223,8 +322,50 @@ interface IFacility {
   network_id: string
   network_region: string
   description: string | null
+  npi_id: string | null
+  location: ILocation | null
   units: IUnit[]
+  created_at?: string | null
+  updated_at?: string | null
 }
+```
+
+### IFacilityPollutionParams
+
+Parameters for the `/pollution/facilities` endpoint:
+
+```typescript
+interface IFacilityPollutionParams {
+  facility_code?: string[]
+  pollutant_code?: PollutantCode[]
+  pollutant_category?: PollutantCategory[]
+  dateStart?: string
+  dateEnd?: string
+}
+```
+
+### PollutantCategory
+
+```typescript
+type PollutantCategory =
+  | "air_pollutant"
+  | "water_pollutant"
+  | "heavy_metal"
+  | "organic"
+```
+
+### PollutantCode
+
+```typescript
+type PollutantCode =
+  // Air pollutants
+  | "nox" | "so2" | "co" | "pm10" | "pm2_5" | "voc" | "ammonia" | "hcl"
+  // Heavy metals
+  | "as" | "cd" | "cr3" | "cr6" | "cu" | "hg" | "ni" | "pb" | "zn"
+  // Organic compounds
+  | "benzene" | "formaldehyde" | "pah" | "dioxins"
+  // Other
+  | "fluoride"
 ```
 
 ### IFacilityDataRow
@@ -280,10 +421,115 @@ class OpenElectricityError extends Error {
 
 ### NoDataFound
 
-Error type for when no data matches the query (416 status):
+Error type thrown when no data matches the query (HTTP 404):
 
 ```typescript
 class NoDataFound extends Error {
   constructor(message: string = "No data found")
 }
+```
+
+## API Response Types
+
+### IAPIResponse
+
+Standard envelope returned by the API:
+
+```typescript
+interface IAPIResponse<T> {
+  version?: string
+  created_at?: string
+  success: boolean
+  error: string | null
+  data: T
+  total_records?: number
+}
+```
+
+`version` and `created_at` are optional — the `/me` endpoint may omit them.
+
+### IValidationErrorDetail
+
+Structured validation error details surfaced on `OpenElectricityError.details`:
+
+```typescript
+interface IValidationErrorDetail {
+  error?: string
+  supported_metrics?: string[]
+  requested_metrics?: string[]
+  invalid_metrics?: string[]
+  hint?: string
+  [key: string]: unknown
+}
+```
+
+### IMetricsResponse
+
+Response shape from `getAvailableMetrics()`:
+
+```typescript
+interface IMetricMetadata {
+  name: string
+  unit: string
+  description: string
+  default_aggregation: string
+  precision: number
+}
+
+interface IMetricsResponse {
+  metrics: Record<string, IMetricMetadata>
+  total: number
+  endpoints: {
+    market: string[]
+    data: string[]
+  }
+}
+```
+
+## User Types
+
+### IUser
+
+```typescript
+interface IUser {
+  id: string
+  full_name: string
+  email: string
+  owner_id: string
+  plan: UserPlan
+  meta: IUserMeta
+  rate_limit?: number
+  unkey_meta?: Record<string, unknown>
+  roles?: OpenNEMRolesType[]
+}
+
+interface IUserMeta {
+  remaining: number
+}
+```
+
+### UserPlan
+
+```typescript
+type UserPlan = "COMMUNITY" | "BASIC" | "PRO" | "ENTERPRISE"
+```
+
+### OpenNEMRolesType
+
+```typescript
+type OpenNEMRolesType =
+  | "admin"
+  | "pro"
+  | "academic"
+  | "user"
+  | "anonymous"
+```
+
+A matching `OpenNEMRoles` const is also exported for autocomplete:
+
+```typescript
+import { OpenNEMRoles } from "openelectricity"
+
+OpenNEMRoles.ADMIN  // "admin"
+OpenNEMRoles.PRO    // "pro"
 ```


### PR DESCRIPTION
sync the in-platform TS SDK docs with the 0.9.0 release of openelectricity npm package (https://github.com/opennem/openelectricity-typescript/releases — release tag pending).

## types.mdx
- DataMetric: add pollution, renewable_proportion, storage_battery
- DataSecondaryGrouping: drop dispatch_type, add status
- INetworkTimeSeriesParams now extends IMarketTimeSeriesParams; adds fueltech/fueltech_group/network_region; secondaryGrouping is array
- IFacilityTimeSeriesParams: add unitCodes
- IMarketTimeSeriesParams: add network_region
- IFacility: add npi_id, location, created_at, updated_at
- new sections: Unit Types, pollution types, API response types (IAPIResponse with optional version/created_at, IValidationErrorDetail, IMetricsResponse), User types (UserPlan adds COMMUNITY, OpenNEMRolesType, IUser optional rate_limit/unkey_meta/roles)
- NoDataFound: 416 -> 404
- typo fix: 'Seasonal intervalsanal'

## reference.mdx
- getNetworkData: document fueltech/fueltech_group/network_region; secondaryGrouping is array
- getFacilityData: document unitCodes
- getMarket: expand metric list (renewable/flow); document network_region
- new sections: getFacilityPollution, getAvailableMetrics
- getCurrentUser: document plan/roles/rate_limit

## test plan
- [ ] mintlify renders without error
- [ ] cross-check against openelectricity-typescript@0.9.0 src/types.ts and src/client.ts