### PR TITLE
fix(wem): confine price aggregate change to WEM + harden parser

### DIFF
--- a/opennem/aggregates/market_summary.py
+++ b/opennem/aggregates/market_summary.py
@@ -149,17 +149,24 @@ async def _get_market_summary_data(
     ),
     gapfilled_data AS (
         -- Generate complete time series with gap filling for each region.
-        -- Price: prefer price_dispatch (5-min dispatch clearing price, populated
-        -- for WEM by the WEMDE dispatch crawler) and fall back to price (5-min
-        -- for NEM, 30-min trading interval for WEM). locf() carries the trading
-        -- price forward across the 5-min buckets within its 30-min interval —
-        -- semantically correct since the trading price IS the price for that
-        -- whole trading interval.
+        -- Price: for WEM, prefer price_dispatch (5-min dispatch clearing price
+        -- from the WEMDE dispatch crawler), fall back to price (30-min trading
+        -- interval), and locf() across the 5-min buckets within each trading
+        -- interval — semantically correct since the trading price IS the price
+        -- for that whole 30-min interval. For NEM, keep avg(price): both
+        -- price and price_dispatch are already 5-min cadence (populated by the
+        -- trading_price and dispatch_price tables); locf would fabricate
+        -- values across legitimate source gaps and preferring price_dispatch
+        -- could silently mask settled-price corrections.
         SELECT
             time_bucket_gapfill('5 minutes', interval, :start_time_window, :end_time) as interval,
             network_id,
             network_region,
-            locf(avg(CAST(COALESCE(price_dispatch, price) AS double precision))) as price,
+            CASE
+                WHEN network_id = 'WEM'
+                    THEN locf(avg(CAST(COALESCE(price_dispatch, price) AS double precision)))
+                ELSE avg(CAST(price AS double precision))
+            END as price,
             avg(CAST(demand AS double precision)) as demand,
             avg(CAST(demand_total AS double precision)) as demand_total,
             avg(ROUND((ss_solar_uigf - ss_solar_clearedmw)::numeric, 4)) as curtailment_solar_total,

--- a/opennem/clients/wemde.py
+++ b/opennem/clients/wemde.py
@@ -180,7 +180,10 @@ async def wemde_parse_dispatch(url: str) -> list[FacilityScadaSchema | Balancing
 
             interval = datetime.fromisoformat(interval_entry["dispatchInterval"]).replace(tzinfo=None)
 
-            # 5-min dispatch energy price (binding interval only)
+            # 5-min dispatch energy price (binding interval only). Catch float()
+            # errors too — a non-numeric prices.energy would otherwise escape
+            # this try/except and reach the per-file catch in run_wemde_crawl,
+            # which would discard the file's FacilityScada records as well.
             energy_price = (interval_entry.get("prices") or {}).get("energy")
             if energy_price is not None:
                 try:
@@ -192,8 +195,8 @@ async def wemde_parse_dispatch(url: str) -> list[FacilityScadaSchema | Balancing
                             price_dispatch=float(energy_price),
                         )
                     )
-                except ValidationError as e:
-                    logger.error(f"Validation error parsing dispatch price for {interval}: {e}")
+                except (ValidationError, ValueError, TypeError) as e:
+                    logger.error(f"Error parsing dispatch price {energy_price!r} for {interval}: {e}")
 
             energy_schedule = next(
                 (s for s in interval_entry.get("schedule", []) if s.get("marketService") == "energy"),

--- a/tests/clients/test_wemde_dispatch.py
+++ b/tests/clients/test_wemde_dispatch.py
@@ -99,3 +99,27 @@ async def test_wemde_dispatch_no_price_field(monkeypatch):
 
     assert any(isinstance(r, FacilityScadaSchema) for r in records)
     assert not any(isinstance(r, BalancingSummarySchema) for r in records)
+
+
+@pytest.mark.asyncio
+async def test_wemde_dispatch_malformed_price_keeps_generation(monkeypatch):
+    """Non-numeric prices.energy must not discard the file's FS records."""
+
+    async def _fake_dl(_url: str) -> list[dict]:
+        # energy price is a non-numeric string — float() will raise ValueError.
+        # The parser must swallow this, emit no BS row, and still return the
+        # FacilityScada records for the binding interval.
+        return [_make_dispatch_json(energy_price="not-a-number")]
+
+    async def _fake_battery_map():
+        return {}
+
+    monkeypatch.setattr(wemde, "_wemde_download_dataset", _fake_dl)
+    monkeypatch.setattr(wemde, "get_battery_unit_map", _fake_battery_map)
+
+    records = await wemde.wemde_parse_dispatch("ignored")
+
+    fs = [r for r in records if isinstance(r, FacilityScadaSchema)]
+    bs = [r for r in records if isinstance(r, BalancingSummarySchema)]
+    assert len(fs) == 2  # both facility schedule entries preserved
+    assert bs == []


### PR DESCRIPTION
review followup to #538. two medium issues surfaced by codex post-merge:

## R-001: aggregate change leaked to NEM

#538 introduced \`locf(avg(COALESCE(price_dispatch, price)))\` to surface 5-min WEM dispatch prices, but the query has no WEM filter — it runs for all networks. NEM populates \`price_dispatch\` from the dispatch_price table (verified 3480/3485 prod rows), so the change silently shifted NEM aggregation:

- before: \`avg(price)\` (settled 5-min)
- after: \`locf(avg(COALESCE(price_dispatch, price)))\`

In practice NEM \`price\` and \`price_dispatch\` are equal so dev/prod NSW1 prices match exactly today — the regression is latent, not active. But locf would fabricate values across any 5-min NEM source gap, and any future divergence between settled and dispatch price would silently prefer dispatch.

fix: \`CASE WHEN network_id='WEM' THEN locf(COALESCE(...)) ELSE avg(price) END\`. NEM behavior reverts to exactly what production has now.

## R-002: malformed dispatch price drops the file's generation

\`float(energy_price)\` on a non-numeric value raises \`ValueError\`. The parser's try/except only catches \`ValidationError\`, so the exception propagates to \`run_wemde_crawl\`'s per-file catch — which discards the file's FacilityScada generation records along with the bad price. Low probability but trivial to fix.

fix: widen catch to \`(ValidationError, ValueError, TypeError)\`. New test \`test_wemde_dispatch_malformed_price_keeps_generation\` covers it.

## Verification

- \`uv run pytest tests/clients/test_wemde_dispatch.py\`: 3/3 pass (including new test)
- ruff lint + format: clean
- dev NEM NSW1 prices unchanged dev↔prod after R-001 fix (we already verified equality before the fix; CASE WHEN makes NEM strictly avg(price) so no possibility of divergence)