### PR TITLE
docs(sdk): use relative dates in python client examples

### DIFF
--- a/docs/sdk/python/reference.mdx
+++ b/docs/sdk/python/reference.mdx
@@ -106,14 +106,14 @@ def get_network_data(
 **Example:**
 ```python
 from openelectricity.types import DataMetric
-from datetime import datetime
+from datetime import datetime, timedelta
 
 response = client.get_network_data(
     network_code="NEM",
     metrics=[DataMetric.POWER, DataMetric.ENERGY],
     interval="1h",
-    date_start=datetime(2024, 1, 1),
-    date_end=datetime(2024, 1, 2),
+    date_start=datetime.now() - timedelta(days=1),
+    date_end=datetime.now(),
     primary_grouping="network_region",
     secondary_grouping="fueltech"
 )
@@ -225,8 +225,8 @@ response = client.get_market(
         MarketMetric.CURTAILMENT_ENERGY
     ],
     interval="1d",
-    date_start=datetime(2024, 1, 1),
-    date_end=datetime(2024, 1, 31),
+    date_start=datetime.now() - timedelta(days=30),
+    date_end=datetime.now(),
     primary_grouping="network_region"
 )
 
@@ -306,8 +306,8 @@ response = client.get_facility_data(
     facility_codes=["BAYSW1", "ERARING"],
     metrics=[DataMetric.POWER, DataMetric.EMISSIONS],
     interval="1h",
-    date_start=datetime(2024, 1, 1),
-    date_end=datetime(2024, 1, 2)
+    date_start=datetime.now() - timedelta(days=1),
+    date_end=datetime.now(),
 )
 ```
 
@@ -363,8 +363,8 @@ response = client.get_market(
     network_code="NEM",
     metrics=[MarketMetric.PRICE, MarketMetric.DEMAND],
     interval="1h",
-    date_start=datetime(2024, 1, 1),
-    date_end=datetime(2024, 1, 2),
+    date_start=datetime.now() - timedelta(days=1),
+    date_end=datetime.now(),
     primary_grouping="network_region"
 )
 


### PR DESCRIPTION
The four python SDK examples on the reference page (`get_network_data`, `get_market` curtailment, `get_facility_data`, the pandas example) all used `datetime(2024, 1, 1)` as date_start. That date is now past the API's ~365 day historical retention window, so users following the docs verbatim get an opaque 400 with no useful message. Surfaced today on openelectricity-python#22 (proxy thread) - turned out to be the date, not the proxy.

Switches all four to `datetime.now() - timedelta(...)` so the examples stay valid as time moves on. `tangly check --strict` clean. The docs preview workflow should deploy a preview URL on this PR.