### PR TITLE
fix(stats): gapfill monthly/yearly series onto calendar grid (#548)

### DIFF
--- a/opennem/api/stats/controllers.py
+++ b/opennem/api/stats/controllers.py
@@ -5,6 +5,7 @@ from textwrap import dedent
 from typing import Any
 
 from datetime_truncate import truncate as date_trunc
+from dateutil.relativedelta import relativedelta
 from sqlalchemy import text as sql
 
 from opennem import settings
@@ -48,9 +49,14 @@ def stats_factory(
     cast_nulls: bool | None = True,
     include_code: bool = True,
     exclude_nulls: bool = True,
+    fill_monthly_gaps: bool = True,
 ) -> OpennemDataSet:
     """
     Takes a list of data query results and returns OpennemDataSets
+
+    :param fill_monthly_gaps: reindex 1M/1Y series onto a complete calendar grid
+        (nulls for missing periods) so static file exports stay aligned. Off for
+        the live API, which returns sparse x,y where missing periods are expected.
 
     @TODO optional groupby field
     @TODO multiple groupings / slight refactor
@@ -83,13 +89,22 @@ def stats_factory(
         # contiguous between start and last. Consumers reconstruct each point's
         # time as start + i*interval, so missing intervals must be explicit
         # nulls — absent rows misalign everything after a gap (issue #534).
-        # Fixed-duration intervals only; month/year stepping is not uniform.
-        grid_step = {
+        grid_step: timedelta | relativedelta | None = {
             "5 minutes": timedelta(minutes=5),
             "30 minutes": timedelta(minutes=30),
             "1 hour": timedelta(hours=1),
             "1 day": timedelta(days=1),
         }.get(interval.interval_sql)
+
+        # Calendar intervals (month/year) step non-uniformly so they need
+        # relativedelta. Only gridded for static file exports — the live API
+        # returns sparse x,y pairs where a missing month/year is expected, so it
+        # opts out via fill_monthly_gaps=False (issue #548).
+        if grid_step is None and fill_monthly_gaps:
+            grid_step = {
+                "1 month": relativedelta(months=1),
+                "1 year": relativedelta(years=1),
+            }.get(interval.interval_sql)
 
         if grid_step and len(data_sorted) > 1:
             grid_keys = list(data_sorted.keys())

--- a/opennem/api/stats/router.py
+++ b/opennem/api/stats/router.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import date, datetime, timedelta
+from functools import partial
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -38,8 +39,14 @@ from opennem.schema.time import TimePeriod
 from opennem.users.schema import OpenNEMRoles, OpenNEMUser
 from opennem.utils.dates import get_last_completed_interval_for_network, get_today_nem
 
-from .controllers import get_scada_range, get_scada_range_optimized, stats_factory
+from .controllers import get_scada_range, get_scada_range_optimized
+from .controllers import stats_factory as _stats_factory
 from .schema import DataQueryResult, OpennemDataSet
+
+# The live API returns sparse x,y series — a missing month/year is expected and
+# consumers handle the nulls — so it opts out of the static-export calendar
+# gapfill that keeps file exports aligned (issue #548).
+stats_factory = partial(_stats_factory, fill_monthly_gaps=False)
 
 
 def _deprecated_endpoint(*_args, **_kwargs):

--- a/tests/test_stats_factory_gapfill.py
+++ b/tests/test_stats_factory_gapfill.py
@@ -1,0 +1,132 @@
+"""Calendar (month/year) gapfill in stats_factory.
+
+Static file exports reconstruct each point's time as ``start + i*interval``, so a
+source gap in a monthly/yearly series must become an explicit null — otherwise
+every value after the gap shifts earlier in time and the tail blanks out
+(issue #548, the NSW1 May gas_ocgt mismatch). The live API opts out via
+``fill_monthly_gaps=False`` because it returns sparse x,y where missing periods
+are expected.
+"""
+
+from datetime import datetime
+
+from opennem.api.stats.controllers import stats_factory
+from opennem.api.stats.schema import DataQueryResult, OpennemDataSet
+from opennem.api.time import human_to_interval
+from opennem.core.networks import network_from_network_code
+from opennem.core.units import get_unit
+
+
+def _run(rows: list[tuple[datetime, float | None]], interval_human: str, fill_monthly_gaps: bool = True) -> OpennemDataSet:
+    """Build a single-group series and push it through stats_factory."""
+    network = network_from_network_code("NEM")
+    stats = [DataQueryResult(interval=dt, result=v, group_by="gas_ocgt") for dt, v in rows]
+
+    result = stats_factory(
+        stats,
+        code="NSW1",
+        network=network,
+        interval=human_to_interval(interval_human),
+        units=get_unit("energy_giga"),
+        region="NSW1",
+        fueltech_group=True,
+        fill_monthly_gaps=fill_monthly_gaps,
+    )
+
+    if not result or not result.data:
+        raise Exception("Bad unit test data — no result")
+
+    return result
+
+
+def test_monthly_gap_is_filled_and_aligned() -> None:
+    """A missing month becomes an explicit null so later values stay aligned."""
+    rows = [
+        (datetime(2024, 1, 1), 10.0),
+        (datetime(2024, 2, 1), 20.0),
+        # 2024-03 missing in source
+        (datetime(2024, 4, 1), 40.0),
+    ]
+
+    history = _run(rows, "1M").data[0].history
+
+    assert history.interval == "1M"
+    assert len(history.data) == 4, "Jan..Apr inclusive = 4 monthly slots"
+    assert history.data == [10.0, 20.0, None, 40.0], "March is an explicit null, April stays at index 3"
+
+    # the contract consumers rely on: data[i] is at start + i months
+    assert history.start.year == 2024 and history.start.month == 1
+    assert history.last.year == 2024 and history.last.month == 4
+
+
+def test_monthly_gap_reproduces_issue_548_offset() -> None:
+    """Without the gap, the trailing value would land a month too early."""
+    rows = [
+        (datetime(2024, 1, 1), 10.0),
+        (datetime(2024, 2, 1), 20.0),
+        (datetime(2024, 4, 1), 40.0),
+    ]
+
+    filled = _run(rows, "1M", fill_monthly_gaps=True).data[0].history
+    sparse = _run(rows, "1M", fill_monthly_gaps=False).data[0].history
+
+    # April's value sits at the April index when filled (3), but at the March
+    # index (2) when sparse — exactly the misalignment behind issue #548.
+    assert filled.data.index(40.0) == 3
+    assert sparse.data.index(40.0) == 2
+
+
+def test_api_opt_out_keeps_series_sparse() -> None:
+    """The live API (fill_monthly_gaps=False) leaves gaps absent, not null."""
+    rows = [
+        (datetime(2024, 1, 1), 10.0),
+        (datetime(2024, 2, 1), 20.0),
+        (datetime(2024, 4, 1), 40.0),
+    ]
+
+    history = _run(rows, "1M", fill_monthly_gaps=False).data[0].history
+
+    assert len(history.data) == 3, "No null inserted for the missing month"
+    assert history.data == [10.0, 20.0, 40.0]
+
+
+def test_contiguous_monthly_series_unchanged() -> None:
+    """A dense series (no gaps) is identical with or without gapfill."""
+    rows = [
+        (datetime(2024, 1, 1), 10.0),
+        (datetime(2024, 2, 1), 20.0),
+        (datetime(2024, 3, 1), 30.0),
+    ]
+
+    filled = _run(rows, "1M", fill_monthly_gaps=True).data[0].history
+    sparse = _run(rows, "1M", fill_monthly_gaps=False).data[0].history
+
+    assert filled.data == [10.0, 20.0, 30.0]
+    assert filled.data == sparse.data
+
+
+def test_yearly_gap_is_filled() -> None:
+    """Year stepping fills a missing calendar year with a null."""
+    rows = [
+        (datetime(2020, 1, 1), 100.0),
+        # 2021 missing
+        (datetime(2022, 1, 1), 300.0),
+    ]
+
+    history = _run(rows, "1Y").data[0].history
+
+    assert history.interval == "1Y"
+    assert history.data == [100.0, None, 300.0]
+
+
+def test_misaligned_keys_are_not_regridded() -> None:
+    """Irregular keys (not on a uniform month step) are preserved, not dropped."""
+    rows = [
+        (datetime(2024, 1, 1), 10.0),
+        (datetime(2024, 2, 15), 20.0),  # off the Jan-01 monthly grid
+    ]
+
+    history = _run(rows, "1M").data[0].history
+
+    # guard skips gapfill rather than dropping the unaligned point
+    assert history.data == [10.0, 20.0]


### PR DESCRIPTION
## issue
#548 — NSW1 monthly `all.json` showed gas at **16.3 GWh** for May 2026 while the daily 1y view showed **71 GWh**.

## root cause
`stats_factory` built `history.data` from only the rows a query returned. Sparse fueltechs (NSW1 `gas_ocgt` had ~81 months of zero generation with no source rows) produced a monthly array shorter than its declared `start..last` span. Consumers reconstruct each point's time as `start + i*interval`, so every value after a gap shifts earlier and the tail blanks out. gas_ocgt's array ended at 2019-08 instead of 2026-05 → May read empty → only gas_ccgt counted (16.3).

The daily/5m gapfill (#535) deliberately skipped month/year stepping, so the daily `2026.json` was correct (70.75) — hence the two views disagreed.

## fix
- `stats_factory` gains `fill_monthly_gaps: bool = True`; when the interval is `1 month`/`1 year` it reindexes onto a contiguous calendar grid via `relativedelta`, inserting explicit nulls for missing periods. Same "only adopt grid if every original key is preserved" guard as the existing daily path.
- Live API (`api/stats/router.py`) opts out via `partial(stats_factory, fill_monthly_gaps=False)` — sparse x,y is expected there. Static export controllers keep the default.

## validation
- 6 new unit tests (`tests/test_stats_factory_gapfill.py`): monthly gap filled+aligned, #548 offset repro, API opt-out stays sparse, contiguous unchanged, yearly gap, misaligned keys safely skipped.
- Real dev export: 0 misaligned series (no regression), gas May total 70.75 unchanged.
- Injected prod-shaped interior gap on real dev `gas_ocgt`: fill=OFF → May misreads 0.43 GWh (bug), fill=ON → 54.44 GWh (fixed).
- Codex review: no findings.

Fixes #548