### PR TITLE
fix(api): wire status into data secondary_grouping (#539)

### DIFF
--- a/opennem/api/queries.py
+++ b/opennem/api/queries.py
@@ -269,6 +269,10 @@ def get_timeseries_query(
                 inner_extra_groups.append("fueltech_group_id")
                 outer_extra_groups.append("fueltech_group_id")
                 secondary_select_aliases.append("fueltech_group_id AS fueltech_group")
+            elif sg == SecondaryGrouping.STATUS:
+                inner_extra_groups.append("status_id")
+                outer_extra_groups.append("status_id")
+                secondary_select_aliases.append("status_id AS status")
 
     # Time column on the base table is `interval` for both unit_intervals and market_summary.
     time_col = "interval"
@@ -322,6 +326,8 @@ def get_timeseries_query(
             aliased_outer_groups.append("fueltech_id AS fueltech")
         elif col == "fueltech_group_id":
             aliased_outer_groups.append("fueltech_group_id AS fueltech_group")
+        elif col == "status_id":
+            aliased_outer_groups.append("status_id AS status")
         else:
             aliased_outer_groups.append(col)
     outer_select_groups = [f"'{network.code}' AS network", *aliased_outer_groups]
@@ -360,6 +366,8 @@ def get_timeseries_query(
                 column_names.append("fueltech")
             elif sg == SecondaryGrouping.FUELTECH_GROUP:
                 column_names.append("fueltech_group")
+            elif sg == SecondaryGrouping.STATUS:
+                column_names.append("status")
     column_names.extend(m.value.lower() for m in metrics)
 
     return sql, params, column_names

--- a/opennem/api/timeseries.py
+++ b/opennem/api/timeseries.py
@@ -133,6 +133,7 @@ _GROUPING_COL = {
     SecondaryGrouping.RENEWABLE: "renewable",
     SecondaryGrouping.FUELTECH: "fueltech",
     SecondaryGrouping.FUELTECH_GROUP: "fueltech_group",
+    SecondaryGrouping.STATUS: "status",
 }
 
 # Grouping enum value → labels dict key (same for most, but explicit)
@@ -140,6 +141,7 @@ _GROUPING_LABEL = {
     SecondaryGrouping.RENEWABLE: "renewable",
     SecondaryGrouping.FUELTECH: "fueltech",
     SecondaryGrouping.FUELTECH_GROUP: "fueltech_group",
+    SecondaryGrouping.STATUS: "status",
 }
 
 

--- a/tests/api/test_queries_power_agg.py
+++ b/tests/api/test_queries_power_agg.py
@@ -17,6 +17,7 @@ import pytest
 
 from opennem.api.data.schema import DataMetric
 from opennem.api.queries import QueryType, get_timeseries_query
+from opennem.core.grouping import SecondaryGrouping
 from opennem.core.time_interval import Interval
 from opennem.schema.network import NetworkNEM
 
@@ -84,3 +85,34 @@ def test_network_aggregate_power_collapses_units_in_inner():
     assert "sum(generated) AS generated_sum" in sql
     # Outer averages the per-5min network totals → network-aggregate avg over the bucket
     assert "round(avg(generated_sum), 6) AS power" in sql
+
+
+@pytest.mark.parametrize(
+    ("grouping", "col"),
+    [
+        (SecondaryGrouping.FUELTECH, "fueltech_id"),
+        (SecondaryGrouping.FUELTECH_GROUP, "fueltech_group_id"),
+        (SecondaryGrouping.STATUS, "status_id"),
+        (SecondaryGrouping.RENEWABLE, "renewable"),
+    ],
+)
+def test_secondary_grouping_emits_column(grouping, col):
+    """Every SecondaryGrouping must wire its source column into the query + column_names.
+
+    Regression for opennem#539: secondary_grouping=status 500'd because the STATUS
+    branch was missing from the query builder and the timeseries label dicts, so
+    status_id was never grouped/selected and label-building raised KeyError.
+    """
+    sql, _, column_names = get_timeseries_query(
+        query_type=QueryType.DATA,
+        network=NetworkNEM,
+        metrics=[DataMetric.ENERGY],
+        interval=Interval.DAY,
+        date_start=datetime(2026, 5, 22, 0, 0),
+        date_end=datetime(2026, 5, 23, 0, 0),
+        secondary_groupings=[grouping],
+    )
+    # source column is grouped/selected in the SQL
+    assert col in sql
+    # output column name is present for callers to zip with row tuples
+    assert grouping.value in column_names


### PR DESCRIPTION
## what

`/v4/data/network/{code}?secondary_grouping=status` returned a 500 while `fueltech` / `fueltech_group` / `renewable` worked. Refs #539 (do NOT auto-close — keep open until confirmed on prod).

## root cause

`SecondaryGrouping.STATUS` is advertised as a valid value (enum + OpenAPI schema), but three code paths that translate it into SQL + response labels had no `STATUS` branch:

- `api/queries.py` — secondary-grouping → SQL columns (never grouped/selected `status_id`)
- `api/queries.py` — `column_names` construction (never appended `status`)
- `api/timeseries.py` — `_GROUPING_COL` / `_GROUPING_LABEL` dicts

The 500 fired in `format_timeseries_response` → `_build_label_key_and_labels`: `_GROUPING_COL[STATUS]` raised `KeyError`. That call sits outside the query-exec try/except, so it propagated uncaught → FastAPI generic 500. Exactly matches the symptom (only `status` fails).

`unit_intervals` already has `status_id String` (clickhouse/schema.py:58) and the aggregation populates it, so no schema work needed — purely wiring.

## change

- group/select `status_id`, alias to `status`, add to `column_names`
- add `STATUS` to the two timeseries label dicts
- parametrized regression test covering all 4 secondary groupings

## test

`uv run pytest tests/api/test_queries_power_agg.py` → 17 passed. ruff + pyright clean.

## verify on prod (before closing #539)

```
curl -H 'Authorization: Bearer ...' \
  'https://api.openelectricity.org.au/v4/data/network/NEM?metrics=energy&interval=1d&date_start=2026-05-22T00:00:00&date_end=2026-05-23T00:00:00&secondary_grouping=status'
```
expect 200 with series split by status (operating / retired / committed).

