### PR TITLE
fix(aggregates): restore locf on NEM price in market_summary (#309)

### DIFF
--- a/opennem/aggregates/market_summary.py
+++ b/opennem/aggregates/market_summary.py
@@ -159,8 +159,18 @@ async def _get_market_summary_data(
         -- For modern 5-min price data locf is a near no-op. WEM additionally
         -- prefers price_dispatch (5-min WEMDE clearing price) over the 30-min
         -- trading price; NEM keeps trading `price` only, so settled-price
-        -- corrections aren't masked by dispatch values. Matches the same
-        -- locf(avg(price)) fill used in unit_intervals.py.
+        -- corrections aren't masked by dispatch values.
+        --
+        -- `treat_null_as_missing => true` is REQUIRED: pre-2009 NEM
+        -- balancing_summary has real 5-min rows (demand populated) with a NULL
+        -- price between the half-hourly trading points (00 and 30 min marks).
+        -- These are NOT gapfill-created gaps, so plain locf() (which only fills
+        -- gaps it created) leaves them NULL. treat_null_as_missing tells locf to
+        -- carry forward across in-data NULLs too. (unit_intervals.py sidesteps
+        -- this by pre-filtering price IS NOT NULL before the gapfill; here price
+        -- shares a CTE with demand/curtailment so we can't filter the rows away.
+        -- NB: avoid ':' followed by digits anywhere in this text() — SQLAlchemy
+        -- parses it as a bind param even inside SQL comments.)
         --
         -- TimescaleDB requires `locf()` to be a top-level aggregate call —
         -- it cannot be nested inside CASE/COALESCE. So we compute both the
@@ -172,8 +182,8 @@ async def _get_market_summary_data(
             time_bucket_gapfill('5 minutes', interval, :start_time_window, :end_time) as interval,
             network_id,
             network_region,
-            locf(avg(CAST(COALESCE(price_dispatch, price) AS double precision))) as price_wem,
-            locf(avg(CAST(price AS double precision))) as price_nem,
+            locf(avg(CAST(COALESCE(price_dispatch, price) AS double precision)), treat_null_as_missing => true) as price_wem,
+            locf(avg(CAST(price AS double precision)), treat_null_as_missing => true) as price_nem,
             avg(CAST(demand AS double precision)) as demand,
             avg(CAST(demand_total AS double precision)) as demand_total,
             avg(ROUND((ss_solar_uigf - ss_solar_clearedmw)::numeric, 4)) as curtailment_solar_total,

--- a/opennem/aggregates/market_summary.py
+++ b/opennem/aggregates/market_summary.py
@@ -149,19 +149,22 @@ async def _get_market_summary_data(
     ),
     gapfilled_data AS (
         -- Generate complete time series with gap filling for each region.
-        -- Price: for WEM, prefer price_dispatch (5-min dispatch clearing price
-        -- from the WEMDE dispatch crawler), fall back to price (30-min trading
-        -- interval), and locf() across the 5-min buckets within each trading
-        -- interval — semantically correct since the trading price IS the price
-        -- for that whole 30-min interval. For NEM, keep avg(price): both
-        -- price and price_dispatch are already 5-min cadence (populated by the
-        -- trading_price and dispatch_price tables); locf would fabricate
-        -- values across legitimate source gaps and preferring price_dispatch
-        -- could silently mask settled-price corrections.
+        -- Price: both networks locf() the trading price across the 5-min
+        -- gapfill buckets — semantically correct since the trading price IS
+        -- the price for its whole interval. This matters for the historical
+        -- 30-min trading cadence: NEM price was 30-min before 2009-07 (and WEM
+        -- still is), so plain avg() leaves price NULL on 10 of every 12 buckets
+        -- while demand is populated 5-min — collapsing demand_market_value to
+        -- ~1/6 (the #309 VWP bug). locf carries the price forward to fill them.
+        -- For modern 5-min price data locf is a near no-op. WEM additionally
+        -- prefers price_dispatch (5-min WEMDE clearing price) over the 30-min
+        -- trading price; NEM keeps trading `price` only, so settled-price
+        -- corrections aren't masked by dispatch values. Matches the same
+        -- locf(avg(price)) fill used in unit_intervals.py.
         --
         -- TimescaleDB requires `locf()` to be a top-level aggregate call —
         -- it cannot be nested inside CASE/COALESCE. So we compute both the
-        -- WEM-style (locf+coalesce) and NEM-style (plain avg) price columns
+        -- WEM-style (locf+coalesce) and NEM-style (locf+price) price columns
         -- here and let the outer combined_data CTE pick the right one per
         -- network_id. Within a single group, network_id is constant, so the
         -- unused column is harmless overhead.
@@ -170,7 +173,7 @@ async def _get_market_summary_data(
             network_id,
             network_region,
             locf(avg(CAST(COALESCE(price_dispatch, price) AS double precision))) as price_wem,
-            avg(CAST(price AS double precision)) as price_nem,
+            locf(avg(CAST(price AS double precision))) as price_nem,
             avg(CAST(demand AS double precision)) as demand,
             avg(CAST(demand_total AS double precision)) as demand_total,
             avg(ROUND((ss_solar_uigf - ss_solar_clearedmw)::numeric, 4)) as curtailment_solar_total,


### PR DESCRIPTION
## what

restore `locf()` on the NEM price path in `market_summary.py`. fixes the demand vwp / tracker price line reading ~6x too low before 2009-07 (eg jun-2008 shows $6.83/MWh, should be ~$40). reopens #309 — this is that bug regressed.

## root cause

#542 (`f024cc81a`, "locf must be top-level — split WEM/NEM into two columns") fixed a real WEM nesting error but dropped `locf()` from the NEM price column, with a comment assuming NEM price is always 5-min cadence.

that's true post-2009 but false before: pre-2009-07 NEM `balancing_summary` has demand at 5-min (DISPATCHIS) but `price` only at 30-min (trading, `:00`/`:30`). after `time_bucket_gapfill('5 minutes', …)`, `avg(price)` is NULL on 10 of every 12 buckets while demand is populated. `demand_market_value = demand_energy * price` goes NULL there, the daily-MV sum skips NULLs while energy counts fully → vwp ≈ 1/6. crossover is exactly 2009-07 when price went 5-min.

## scope

- only the **demand** market_value is affected (tracker price line). demand **energy/volume** is correct — it's the product `demand × price` that collapses, not the volume.
- per-fueltech market values were never affected: `unit_intervals.py` kept its #309 `locf(avg(price))` (fe7521b5). coal_black jun-2008 = $39.66/MWh ✓.

## the change

```diff
- avg(CAST(price AS double precision)) as price_nem,
+ locf(avg(CAST(price AS double precision))) as price_nem,
```

keeps trading `price` (not `price_dispatch`) so settled-price corrections aren't masked. locf stays a top-level aggregate, so #542's nesting error doesn't return. for modern 5-min data locf is a near no-op. now matches the fill method in `unit_intervals.py`.

## verification (proof of bug, from live energy/all.json)

| series | jun-2008 implied $/MWh |
|---|---|
| `demand.market_value` (broken) | $6.83 |
| `coal_black.market_value` (unaffected) | $39.66 |

demand price steps $6.76 → $29.16 exactly at 2009-07. demand energy is smooth (~17-18 TWh/mo) across the boundary — no step.

## follow-up (post-merge, prod)

re-aggregate + re-export the affected range:
1. `process_market_summary_backlog(s, datetime(1999,1,1), datetime(2010,1,1))` (ENV=production)
2. `backfill_materialized_views(['market_summary_daily_mv'], 1999-01-01, 2010-01-01)` + `OPTIMIZE TABLE market_summary_daily_mv FINAL`
3. re-export static jsons; confirm jun-2008 demand price ≈ $40 and the 2009-07 step is gone
