### PR TITLE
fix(api): internal/enterprise key hit COMMUNITY data-range cap (#555)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,12 @@ DATABASE_HOST_URL=postgresql://opennem:opennem@127.0.0.1:${POSTGRES_LOCAL_PORT}/
 REDIS_HOST_URL=redis://127.0.0.1:${REDIS_LOCAL_PORT}
 CLICKHOUSE_HOST_URL=http://127.0.0.1:${CLICKHOUSE_LOCAL_HTTP_PORT}/opennem
 
+# API keys
+# API_DEV_KEY: per-environment dev key (enterprise+admin bypass)
+# API_INTERNAL_KEY: shared internal/enterprise key, recognised in every environment
+API_DEV_KEY=
+API_INTERNAL_KEY=
+
 # Loging level
 LOG_LEVEL=DEBUG
 

--- a/opennem/api/data/router.py
+++ b/opennem/api/data/router.py
@@ -14,7 +14,7 @@ from fastapi_versionizer import api_version
 from opennem.api.data.utils import validate_date_range
 from opennem.api.queries import QueryType, get_timeseries_query
 from opennem.api.schema import std_error_responses
-from opennem.api.security import authenticated_user
+from opennem.api.security import authenticated_user, optional_user
 from opennem.api.timeseries import build_timeseries_response, format_timeseries_response
 from opennem.api.utils import get_api_network_from_code, validate_metrics
 from opennem.core.grouping import PrimaryGrouping, SecondaryGrouping
@@ -86,7 +86,7 @@ async def get_network_data(
         Query(description="Optional secondary grouping dimension.", examples=["fueltech_group"]),
     ] = None,
     client: Any = Depends(get_clickhouse_dependency),
-    user: authenticated_user | None = None,
+    user: optional_user = None,
 ) -> dict:
     """Get time series data for a network."""
     network = get_api_network_from_code(network_code)

--- a/opennem/api/market/router.py
+++ b/opennem/api/market/router.py
@@ -14,7 +14,7 @@ from fastapi_versionizer import api_version
 from opennem.api.data.utils import validate_date_range
 from opennem.api.queries import QueryType, get_timeseries_query
 from opennem.api.schema import std_error_responses
-from opennem.api.security import authenticated_user
+from opennem.api.security import optional_user
 from opennem.api.timeseries import build_timeseries_response, format_timeseries_response
 from opennem.api.utils import get_api_network_from_code, validate_metrics
 from opennem.core.grouping import PrimaryGrouping
@@ -89,7 +89,7 @@ async def get_network_data(
         Query(description="Primary grouping dimension applied to results.", examples=["network_region"]),
     ] = PrimaryGrouping.NETWORK,
     client: Any = Depends(get_clickhouse_dependency),
-    user: authenticated_user | None = None,
+    user: optional_user = None,
 ) -> dict:
     """Get market data for a network."""
     network = get_api_network_from_code(network_code)

--- a/opennem/api/security.py
+++ b/opennem/api/security.py
@@ -28,6 +28,9 @@ clerk_client = Clerk(bearer_auth=settings.clerk_secret_key)
 
 # Bearer token scheme
 api_token_scheme = HTTPBearer()
+# Optional bearer scheme: does not 401 on a missing credential so anonymous
+# requests can be served (at COMMUNITY limits) by optional-auth endpoints.
+api_token_scheme_optional = HTTPBearer(auto_error=False)
 
 # Default internal user for development
 _OPENNEM_INTERNAL_USER = OpenNEMUser(
@@ -69,53 +72,82 @@ def _resolve_admin(private_metadata: dict | None) -> bool:
     return False
 
 
+async def _resolve_user_from_key(key: str) -> OpenNEMUser:
+    """Resolve an OpenNEMUser from a raw API key. Raises HTTPException on failure."""
+    if not key or len(key) < 10:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid API key")
+
+    # Dev/internal key bypass → enterprise admin, full access, no Unkey/Clerk.
+    # api_dev_key is per-environment; api_internal_key is the shared internal key
+    # recognised across every environment (dev + prod).
+    if key == settings.api_dev_key or (settings.api_internal_key and key == settings.api_internal_key):
+        return _OPENNEM_INTERNAL_USER
+
+    # Validate with Unkey
+    user = await unkey_validate(api_key=key)
+
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid API key")
+
+    # Enrich with Clerk user data
+    if not user.owner_id:
+        logger.info(f"No owner_id for user {user.id}, skipping Clerk enrichment")
+        # Resolve plan from unkey meta if available
+        user.plan = _resolve_plan(None, user.unkey_meta)
+        return user
+
+    clerk_user = await clerk_client.users.get_async(user_id=user.owner_id)
+
+    if not clerk_user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
+
+    user.full_name = f"{clerk_user.first_name} {clerk_user.last_name}"
+    user.email = clerk_user.email_addresses[0].email_address
+
+    private_meta = clerk_user.private_metadata if clerk_user.private_metadata else None
+
+    # Resolve plan from Clerk, with Unkey meta fallback
+    user.plan = _resolve_plan(private_meta, user.unkey_meta)
+
+    # Resolve admin from Clerk privateMetadata.role
+    if _resolve_admin(private_meta):
+        if OpenNEMRoles.admin not in user.roles:
+            user.roles.append(OpenNEMRoles.admin)
+
+    return user
+
+
 async def get_current_user(
     authorization: Annotated[HTTPAuthorizationCredentials, Depends(api_token_scheme)],
 ) -> OpenNEMUser:
     """FastAPI dependency: validate API key, resolve plan + roles from Clerk."""
     try:
-        key = authorization.credentials
+        return await _resolve_user_from_key(authorization.credentials)
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.warning(f"Authentication error: {str(e)}")
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Authentication failed") from e
 
-        if not key or len(key) < 10:
-            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid API key")
 
-        # Dev key bypass
-        if key == settings.api_dev_key:
-            return _OPENNEM_INTERNAL_USER
+async def get_optional_user(
+    authorization: Annotated[HTTPAuthorizationCredentials | None, Depends(api_token_scheme_optional)],
+) -> OpenNEMUser | None:
+    """FastAPI dependency for optional auth.
 
-        # Validate with Unkey
-        user = await unkey_validate(api_key=key)
+    Returns ``None`` for anonymous requests (no credential) so the endpoint can
+    serve them at COMMUNITY limits; resolves and validates the key otherwise so
+    a valid key (including the internal/enterprise key) grants its full access.
+    A presented-but-invalid key still 401s.
 
-        if not user:
-            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid API key")
-
-        # Enrich with Clerk user data
-        if not user.owner_id:
-            logger.info(f"No owner_id for user {user.id}, skipping Clerk enrichment")
-            # Resolve plan from unkey meta if available
-            user.plan = _resolve_plan(None, user.unkey_meta)
-            return user
-
-        clerk_user = await clerk_client.users.get_async(user_id=user.owner_id)
-
-        if not clerk_user:
-            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
-
-        user.full_name = f"{clerk_user.first_name} {clerk_user.last_name}"
-        user.email = clerk_user.email_addresses[0].email_address
-
-        private_meta = clerk_user.private_metadata if clerk_user.private_metadata else None
-
-        # Resolve plan from Clerk, with Unkey meta fallback
-        user.plan = _resolve_plan(private_meta, user.unkey_meta)
-
-        # Resolve admin from Clerk privateMetadata.role
-        if _resolve_admin(private_meta):
-            if OpenNEMRoles.admin not in user.roles:
-                user.roles.append(OpenNEMRoles.admin)
-
-        return user
-
+    NOTE: do NOT express optional auth as ``authenticated_user | None = None`` on
+    the endpoint — FastAPI silently drops the nested Depends, so the credential is
+    never read and every request is treated as anonymous. Use this dependency.
+    """
+    if authorization is None:
+        return None
+    try:
+        return await _resolve_user_from_key(authorization.credentials)
     except HTTPException:
         raise
     except Exception as e:
@@ -136,4 +168,5 @@ def check_roles(required_roles: list[OpenNEMRoles]):
 
 # Common auth dependencies
 authenticated_user = Annotated[OpenNEMUser, Depends(get_current_user)]
+optional_user = Annotated[OpenNEMUser | None, Depends(get_optional_user)]
 admin_user = Annotated[OpenNEMUser, Depends(check_roles([OpenNEMRoles.admin]))]

--- a/opennem/api/security.py
+++ b/opennem/api/security.py
@@ -73,61 +73,68 @@ def _resolve_admin(private_metadata: dict | None) -> bool:
 
 
 async def _resolve_user_from_key(key: str) -> OpenNEMUser:
-    """Resolve an OpenNEMUser from a raw API key. Raises HTTPException on failure."""
-    if not key or len(key) < 10:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid API key")
+    """Resolve an OpenNEMUser from a raw API key.
 
-    # Dev/internal key bypass → enterprise admin, full access, no Unkey/Clerk.
-    # api_dev_key is per-environment; api_internal_key is the shared internal key
-    # recognised across every environment (dev + prod).
-    if key == settings.api_dev_key or (settings.api_internal_key and key == settings.api_internal_key):
-        return _OPENNEM_INTERNAL_USER
+    Always raises HTTPException(401) on failure — invalid/short key, unknown key,
+    missing Clerk user, or an unexpected Unkey/Clerk error. Callers (required and
+    optional auth) share these semantics, so the error handling lives here only.
+    """
+    try:
+        if not key or len(key) < 10:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid API key")
 
-    # Validate with Unkey
-    user = await unkey_validate(api_key=key)
+        # Dev/internal key bypass → enterprise admin, full access, no Unkey/Clerk.
+        # api_dev_key is per-environment; api_internal_key is the shared internal key
+        # recognised across every environment (dev + prod). Return a copy so the
+        # shared module-level singleton can never be mutated across requests.
+        if key == settings.api_dev_key or (settings.api_internal_key and key == settings.api_internal_key):
+            return _OPENNEM_INTERNAL_USER.model_copy(deep=True)
 
-    if not user:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid API key")
+        # Validate with Unkey
+        user = await unkey_validate(api_key=key)
 
-    # Enrich with Clerk user data
-    if not user.owner_id:
-        logger.info(f"No owner_id for user {user.id}, skipping Clerk enrichment")
-        # Resolve plan from unkey meta if available
-        user.plan = _resolve_plan(None, user.unkey_meta)
+        if not user:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid API key")
+
+        # Enrich with Clerk user data
+        if not user.owner_id:
+            logger.info(f"No owner_id for user {user.id}, skipping Clerk enrichment")
+            # Resolve plan from unkey meta if available
+            user.plan = _resolve_plan(None, user.unkey_meta)
+            return user
+
+        clerk_user = await clerk_client.users.get_async(user_id=user.owner_id)
+
+        if not clerk_user:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
+
+        user.full_name = f"{clerk_user.first_name} {clerk_user.last_name}"
+        user.email = clerk_user.email_addresses[0].email_address
+
+        private_meta = clerk_user.private_metadata if clerk_user.private_metadata else None
+
+        # Resolve plan from Clerk, with Unkey meta fallback
+        user.plan = _resolve_plan(private_meta, user.unkey_meta)
+
+        # Resolve admin from Clerk privateMetadata.role
+        if _resolve_admin(private_meta):
+            if OpenNEMRoles.admin not in user.roles:
+                user.roles.append(OpenNEMRoles.admin)
+
         return user
 
-    clerk_user = await clerk_client.users.get_async(user_id=user.owner_id)
-
-    if not clerk_user:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
-
-    user.full_name = f"{clerk_user.first_name} {clerk_user.last_name}"
-    user.email = clerk_user.email_addresses[0].email_address
-
-    private_meta = clerk_user.private_metadata if clerk_user.private_metadata else None
-
-    # Resolve plan from Clerk, with Unkey meta fallback
-    user.plan = _resolve_plan(private_meta, user.unkey_meta)
-
-    # Resolve admin from Clerk privateMetadata.role
-    if _resolve_admin(private_meta):
-        if OpenNEMRoles.admin not in user.roles:
-            user.roles.append(OpenNEMRoles.admin)
-
-    return user
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.warning(f"Authentication error: {str(e)}")
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Authentication failed") from e
 
 
 async def get_current_user(
     authorization: Annotated[HTTPAuthorizationCredentials, Depends(api_token_scheme)],
 ) -> OpenNEMUser:
     """FastAPI dependency: validate API key, resolve plan + roles from Clerk."""
-    try:
-        return await _resolve_user_from_key(authorization.credentials)
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.warning(f"Authentication error: {str(e)}")
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Authentication failed") from e
+    return await _resolve_user_from_key(authorization.credentials)
 
 
 async def get_optional_user(
@@ -146,13 +153,7 @@ async def get_optional_user(
     """
     if authorization is None:
         return None
-    try:
-        return await _resolve_user_from_key(authorization.credentials)
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.warning(f"Authentication error: {str(e)}")
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Authentication failed") from e
+    return await _resolve_user_from_key(authorization.credentials)
 
 
 def check_roles(required_roles: list[OpenNEMRoles]):

--- a/opennem/settings_schema.py
+++ b/opennem/settings_schema.py
@@ -65,6 +65,11 @@ class OpennemSettings(BaseSettings):
     # API Dev key
     api_dev_key: str | None = None
 
+    # Internal/enterprise key: recognised in every environment (dev + prod) and
+    # granted full enterprise+admin access, bypassing Unkey/Clerk and data limits.
+    # Distinct from api_dev_key (which is per-env) so one internal key works everywhere.
+    api_internal_key: str | None = None
+
     # webhooks
     webhook_secret: str | None = None
 

--- a/tests/api/test_date_range_limits.py
+++ b/tests/api/test_date_range_limits.py
@@ -1,0 +1,130 @@
+"""Unit tests for data-range limit enforcement (opennem.api.data.utils).
+
+This is the symptom side of #555: the internal/enterprise key must be able to
+pull the full archive (e.g. ``interval=1M`` from 2000-01-01), while anonymous /
+COMMUNITY callers stay capped at 732 days. These tests pin ``get_max_interval_days``
+and ``validate_date_range`` so the cap can't silently regress for higher tiers.
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+from fastapi import HTTPException
+
+from opennem.api.data.utils import get_max_interval_days, validate_date_range
+from opennem.core.time_interval import Interval
+from opennem.schema.network import NetworkNEM
+from opennem.users.plans import OpenNEMPlan
+from opennem.users.schema import OpenNEMRoles, OpenNEMUser
+
+# Full-archive window from the #555 report (2000-01-01 → a fixed recent date).
+_ARCHIVE_START = datetime(2000, 1, 1)
+_ARCHIVE_END = datetime(2026, 6, 9)
+
+_COMMUNITY = OpenNEMUser(id="community", plan=OpenNEMPlan.COMMUNITY, roles=[OpenNEMRoles.anonymous])
+_ENTERPRISE = OpenNEMUser(id="enterprise", plan=OpenNEMPlan.ENTERPRISE, roles=[OpenNEMRoles.anonymous])
+# admin role must lift limits regardless of the plan attached to the key
+_ADMIN = OpenNEMUser(id="admin", plan=OpenNEMPlan.COMMUNITY, roles=[OpenNEMRoles.admin, OpenNEMRoles.anonymous])
+
+
+# --- get_max_interval_days -------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ["user", "expected"],
+    [
+        (None, 732),  # anonymous → COMMUNITY bucket
+        (_COMMUNITY, 732),
+        (_ENTERPRISE, 36500),
+        (_ADMIN, 36500),  # admin role wins even on a COMMUNITY plan
+    ],
+)
+def test_max_interval_days_month(user: OpenNEMUser | None, expected: int) -> None:
+    assert get_max_interval_days(Interval.MONTH, user) == expected
+
+
+def test_max_interval_days_interval_tiers() -> None:
+    """5-minute interval: COMMUNITY is tightly capped, admin/enterprise far higher."""
+    assert get_max_interval_days(Interval.INTERVAL, None) == 8
+    assert get_max_interval_days(Interval.INTERVAL, _ENTERPRISE) == 30
+    assert get_max_interval_days(Interval.INTERVAL, _ADMIN) == 30
+
+
+# --- validate_date_range: the #555 range cap -------------------------------
+
+
+@pytest.mark.parametrize("user", [None, _COMMUNITY])
+def test_full_archive_rejected_for_anonymous_and_community(user: OpenNEMUser | None) -> None:
+    """2000→now at 1M exceeds the 732-day COMMUNITY cap → 400."""
+    with pytest.raises(HTTPException) as exc:
+        validate_date_range(
+            network=NetworkNEM,
+            interval=Interval.MONTH,
+            user=user,
+            date_start=_ARCHIVE_START,
+            date_end=_ARCHIVE_END,
+        )
+    assert exc.value.status_code == 400
+    assert "Maximum range is 732 days" in exc.value.detail
+
+
+@pytest.mark.parametrize("user", [_ENTERPRISE, _ADMIN])
+def test_full_archive_allowed_for_enterprise_and_admin(user: OpenNEMUser) -> None:
+    """The #555 fix: enterprise/admin pull the full archive at 1M without a cap."""
+    start, end = validate_date_range(
+        network=NetworkNEM,
+        interval=Interval.MONTH,
+        user=user,
+        date_start=_ARCHIVE_START,
+        date_end=_ARCHIVE_END,
+    )
+    assert (start, end) == (_ARCHIVE_START, _ARCHIVE_END)
+
+
+# --- validate_date_range: the period (how-far-back) limit ------------------
+
+
+def test_period_limit_blocks_community_far_past() -> None:
+    """COMMUNITY (period_limit_days=730) can't start a window outside the last ~2y,
+    even when the window itself is within the range cap."""
+    far_start = datetime.now() - timedelta(days=900)
+    with pytest.raises(HTTPException) as exc:
+        validate_date_range(
+            network=NetworkNEM,
+            interval=Interval.MONTH,
+            user=_COMMUNITY,
+            date_start=far_start,
+            date_end=far_start + timedelta(days=30),
+        )
+    assert exc.value.status_code == 400
+    assert "too far in the past" in exc.value.detail
+
+
+@pytest.mark.parametrize("user", [_ENTERPRISE, _ADMIN])
+def test_period_limit_bypassed_for_enterprise_and_admin(user: OpenNEMUser) -> None:
+    """ENTERPRISE (period_limit_days=-1) and admin ignore the how-far-back limit."""
+    far_start = datetime.now() - timedelta(days=900)
+    start, end = validate_date_range(
+        network=NetworkNEM,
+        interval=Interval.MONTH,
+        user=user,
+        date_start=far_start,
+        date_end=far_start + timedelta(days=30),
+    )
+    assert start == far_start
+
+
+def test_tz_aware_dates_rejected() -> None:
+    """Dates must be network-local naive; a tz-aware date is a 400."""
+    from datetime import UTC
+
+    with pytest.raises(HTTPException) as exc:
+        validate_date_range(
+            network=NetworkNEM,
+            interval=Interval.MONTH,
+            user=_ENTERPRISE,
+            date_start=_ARCHIVE_START.replace(tzinfo=UTC),
+            date_end=_ARCHIVE_END,
+        )
+    assert exc.value.status_code == 400
+    assert "timezone naive" in exc.value.detail

--- a/tests/api/test_optional_auth.py
+++ b/tests/api/test_optional_auth.py
@@ -67,6 +67,28 @@ def test_per_env_dev_key_also_resolves_enterprise_admin(client: TestClient) -> N
     assert body["admin"] is True
 
 
+@pytest.mark.asyncio
+async def test_internal_key_resolution_is_isolated_per_request() -> None:
+    """The bypass must return a fresh copy, not the shared module-level singleton,
+    so mutating one resolved user can't leak into the next request."""
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(security.settings, "api_internal_key", _INTERNAL_KEY)
+    try:
+        u1 = await security._resolve_user_from_key(_INTERNAL_KEY)
+        u2 = await security._resolve_user_from_key(_INTERNAL_KEY)
+        assert u1 is not u2
+        assert u1.roles is not u2.roles  # roles is a mutable list — must not be shared
+        u1.roles.append(OpenNEMRoles.admin)
+        u1.plan = OpenNEMPlan.COMMUNITY
+        # the singleton and a subsequent resolution are unaffected
+        assert security._OPENNEM_INTERNAL_USER.plan == OpenNEMPlan.ENTERPRISE
+        u3 = await security._resolve_user_from_key(_INTERNAL_KEY)
+        assert u3.plan == OpenNEMPlan.ENTERPRISE
+        assert u3.roles.count(OpenNEMRoles.admin) == 1
+    finally:
+        monkeypatch.undo()
+
+
 def test_invalid_key_is_rejected(client: TestClient) -> None:
     """A presented-but-invalid key must 401 (not silently fall back to anon)."""
     with patch.object(security, "unkey_validate", AsyncMock(return_value=None)):

--- a/tests/api/test_optional_auth.py
+++ b/tests/api/test_optional_auth.py
@@ -1,0 +1,92 @@
+"""Regression tests for optional-auth on the data/market endpoints.
+
+Bug (#555): declaring an endpoint param as ``user: authenticated_user | None = None``
+makes FastAPI silently drop the nested ``Depends(get_current_user)`` — the bearer
+token is never read, so every request (even with a valid internal/enterprise key)
+resolves to ``None`` and is served at anonymous COMMUNITY limits. The fix is the
+dedicated ``optional_user`` dependency (``HTTPBearer(auto_error=False)``).
+
+These tests pin the four auth outcomes so the broken pattern can't sneak back.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from opennem.api import security
+from opennem.api.security import optional_user
+from opennem.users.plans import OpenNEMPlan
+from opennem.users.schema import OpenNEMRoles, OpenNEMUser
+
+_INTERNAL_KEY = "oe_internal_TESTKEY_1234567890"
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    # api_dev_key is a *different* per-env key; the internal key is recognised via
+    # api_internal_key — mirroring dev, where api_dev_key != the internal key.
+    monkeypatch.setattr(security.settings, "api_dev_key", "on_dev_some_other_key_123")
+    monkeypatch.setattr(security.settings, "api_internal_key", _INTERNAL_KEY)
+
+    app = FastAPI()
+
+    @app.get("/probe")
+    async def probe(user: optional_user = None) -> dict:
+        if user is None:
+            return {"auth": "anon", "plan": None, "admin": None}
+        return {"auth": "user", "plan": str(user.plan), "admin": bool(user.is_admin)}
+
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_anonymous_request_resolves_to_none(client: TestClient) -> None:
+    """No credential → served as anonymous (COMMUNITY limits), not rejected."""
+    r = client.get("/probe")
+    assert r.status_code == 200
+    assert r.json() == {"auth": "anon", "plan": None, "admin": None}
+
+
+def test_internal_key_resolves_enterprise_admin(client: TestClient) -> None:
+    """The internal key (via api_internal_key) grants ENTERPRISE + admin in any env."""
+    r = client.get("/probe", headers={"Authorization": f"Bearer {_INTERNAL_KEY}"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["auth"] == "user"
+    assert body["plan"] == str(OpenNEMPlan.ENTERPRISE)
+    assert body["admin"] is True
+
+
+def test_per_env_dev_key_also_resolves_enterprise_admin(client: TestClient) -> None:
+    """The per-environment api_dev_key still works as an enterprise+admin bypass."""
+    r = client.get("/probe", headers={"Authorization": "Bearer on_dev_some_other_key_123"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["plan"] == str(OpenNEMPlan.ENTERPRISE)
+    assert body["admin"] is True
+
+
+def test_invalid_key_is_rejected(client: TestClient) -> None:
+    """A presented-but-invalid key must 401 (not silently fall back to anon)."""
+    with patch.object(security, "unkey_validate", AsyncMock(return_value=None)):
+        r = client.get("/probe", headers={"Authorization": "Bearer bogus_key_abcdef"})
+    assert r.status_code == 401
+
+
+def test_valid_unkey_key_resolves_plan(client: TestClient) -> None:
+    """A valid Unkey key resolves its plan (here PRO via unkey meta)."""
+    fake = OpenNEMUser(
+        id="u1",
+        owner_id=None,
+        plan=OpenNEMPlan.COMMUNITY,
+        roles=[OpenNEMRoles.anonymous],
+        unkey_meta={"plan": "PRO"},
+    )
+    with patch.object(security, "unkey_validate", AsyncMock(return_value=fake)):
+        r = client.get("/probe", headers={"Authorization": "Bearer valid_unkey_key_123456"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["auth"] == "user"
+    assert body["plan"] == str(OpenNEMPlan.PRO)
+    assert body["admin"] is False


### PR DESCRIPTION
closes #555

## what

the internal key got the COMMUNITY 732-day range cap on `/v4/market/network/*` and `/v4/data/network/*` (e.g. `interval=1M&date_start=2000-01-01` → 400 "Maximum range is 732 days"). same error with **no auth header at all** → the key was never even read.

## root cause — a regression

`be9c464b` ("clear pyright errors") changed the optional-auth param from `user: authenticated_user = None` to `user: authenticated_user | None = None` to silence pyright. but FastAPI **silently drops a `Depends` nested inside `Optional[Annotated[...]]`** — so `get_current_user` never ran, the bearer was never validated, and every request resolved as anonymous → COMMUNITY plan → 732-day cap. confirmed in isolation (FastAPI 0.135.1): the broken pattern returns `user=None` even with a valid token.

## fix

- new `get_optional_user` dependency using `HTTPBearer(auto_error=False)`: no credential → `None` (anonymous, served at COMMUNITY), valid key → resolved tier, presented-but-invalid key → 401
- `data`/`market` routers: `authenticated_user | None = None` → `optional_user = None`
- shared `_resolve_user_from_key` helper; centralised the `except → 401` cascade so required + optional auth share one error path
- bypass returns `_OPENNEM_INTERNAL_USER.model_copy(deep=True)` (was returning the shared module-level singleton by reference — latent cross-request state-leak footgun; `roles` is a mutable list)
- new `api_internal_key` setting: a single shared internal key recognised in **every** env (dev + prod), bypassing Unkey/Clerk + data limits. `api_dev_key` stays per-env. (env vars already set in dev + prod.)

result: internal key → ENTERPRISE + admin → `BUCKET_LIMITS_ADMIN[MONTH]`=36500d → full archive from 2000 passes. anonymous still served at COMMUNITY.

## tests

- `test_optional_auth.py`: 4 auth paths (anon→None, internal→enterprise+admin, invalid→401, valid unkey→plan) + per-env dev key + singleton isolation
- `test_date_range_limits.py`: `get_max_interval_days` + `validate_date_range` per tier — full archive rejected for anon/COMMUNITY, allowed for enterprise/admin; period-limit enforced/bypassed correctly

## reviewed — notes / out of scope

- **no cache leak**: both endpoints use `@cache`; the default key builder hashes `kwargs` which includes the resolved `user`, so anonymous (`user=None`) and enterprise get distinct keys — an anon request can't hit an enterprise-populated >732d entry. (the trade-off is some cache fragmentation for authenticated requests; anonymous traffic still shares one key.)
- **follow-up (not in this PR)**: `stats/router.py` `power_station_v4`/`energy_station_v4` still use `user: authenticated_user = None` (the pre-regression pattern — required auth + a dead `= None` default). not broken, but the dead default is the same landmine. worth deciding whether those deprecated endpoints should be optional-auth too, then either migrate to `optional_user` or drop the `= None`.