### PR TITLE
fix(api): cap clickhouse per-query memory on serving path

### DIFF
--- a/opennem/db/clickhouse/client.py
+++ b/opennem/db/clickhouse/client.py
@@ -23,6 +23,27 @@ logger = logging.getLogger("opennem.db.clickhouse")
 _local = threading.local()
 
 
+def _serving_query_settings() -> dict[str, int]:
+    """
+    Per-query ClickHouse limits for the serving path (execute_async).
+
+    Without these a single wide aggregation can grow its GROUP BY hash table until
+    the whole server runs out of memory, at which point the server-wide overcommit
+    tracker kills an arbitrary query (Code 241). Capping per query makes a runaway
+    query fail cleanly on its own and lets large-but-legit GROUP BYs spill to disk.
+
+    A value of 0 in settings disables that individual limit.
+    """
+    out: dict[str, int] = {}
+    if settings.clickhouse_query_max_memory_usage:
+        out["max_memory_usage"] = settings.clickhouse_query_max_memory_usage
+    if settings.clickhouse_query_max_bytes_before_external_group_by:
+        out["max_bytes_before_external_group_by"] = settings.clickhouse_query_max_bytes_before_external_group_by
+    if settings.clickhouse_query_max_execution_time:
+        out["max_execution_time"] = settings.clickhouse_query_max_execution_time
+    return out
+
+
 def _make_client(timeout: int = 10) -> Client:
     return Client(
         host=settings.clickhouse_url.host,
@@ -52,11 +73,16 @@ async def execute_async(client: Client, query: str, params: dict | None = None, 
     Run a blocking clickhouse-driver execute() in a thread so the
     asyncio event loop is not blocked.  Each thread in the pool gets
     its own Client via thread-local storage.
+
+    Conservative per-query resource limits (see ``_serving_query_settings``) are applied
+    by default so one expensive serving query cannot OOM the shared server. Callers can
+    override individual limits by passing ``settings={...}`` (caller keys win per-key).
     """
+    merged_settings = {**_serving_query_settings(), **(kwargs.pop("settings", None) or {})}
 
     def _run() -> Any:
         tl_client = get_clickhouse_client()
-        return tl_client.execute(query, params, **kwargs)
+        return tl_client.execute(query, params, settings=merged_settings, **kwargs)
 
     return await asyncio.to_thread(_run)
 

--- a/opennem/settings_schema.py
+++ b/opennem/settings_schema.py
@@ -38,6 +38,23 @@ class OpennemSettings(BaseSettings):
         description="ClickHouse connection URL in format clickhouse:// schema url",
     )
 
+    # Per-query ClickHouse limits applied on the serving path (execute_async) so a single
+    # expensive API query cannot exhaust server memory and trip the server-wide overcommit
+    # tracker (Code 241), which would kill unrelated concurrent queries. Backfills use the
+    # sync client directly and are unaffected. Set to 0 to disable a given limit.
+    clickhouse_query_max_memory_usage: int = Field(
+        8_589_934_592,  # 8 GiB
+        description="ClickHouse max_memory_usage (bytes) for serving-path queries. 0 = unset.",
+    )
+    clickhouse_query_max_bytes_before_external_group_by: int = Field(
+        4_294_967_296,  # 4 GiB — roughly half of max_memory_usage so GROUP BY spills to disk
+        description="ClickHouse max_bytes_before_external_group_by (bytes) for serving-path queries. 0 = unset.",
+    )
+    clickhouse_query_max_execution_time: int = Field(
+        90,
+        description="ClickHouse max_execution_time (seconds) for serving-path queries. 0 = unset.",
+    )
+
     redis_url: RedisDsn = Field(
         RedisDsn("redis://127.0.0.1"),
         validation_alias=AliasChoices("REDIS_HOST_URL", "cache_url"),

--- a/tests/db/test_clickhouse_client.py
+++ b/tests/db/test_clickhouse_client.py
@@ -1,0 +1,58 @@
+"""Tests for the ClickHouse serving-path query settings applied by execute_async."""
+
+import pytest
+
+from opennem import settings
+from opennem.db.clickhouse import client as ch_client
+
+
+class _FakeClient:
+    """Records the args of the last execute() call."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def execute(self, query, params=None, **kwargs):  # noqa: ANN001, ANN003
+        self.calls.append({"query": query, "params": params, "kwargs": kwargs})
+        return []
+
+
+@pytest.fixture
+def fake_client(monkeypatch: pytest.MonkeyPatch) -> _FakeClient:
+    fake = _FakeClient()
+    monkeypatch.setattr(ch_client, "get_clickhouse_client", lambda *a, **k: fake)
+    return fake
+
+
+@pytest.mark.asyncio
+async def test_execute_async_applies_default_memory_limits(fake_client: _FakeClient) -> None:
+    await ch_client.execute_async(fake_client, "SELECT 1")
+
+    applied = fake_client.calls[-1]["kwargs"]["settings"]
+    assert applied["max_memory_usage"] == settings.clickhouse_query_max_memory_usage
+    assert applied["max_bytes_before_external_group_by"] == settings.clickhouse_query_max_bytes_before_external_group_by
+    assert applied["max_execution_time"] == settings.clickhouse_query_max_execution_time
+
+
+@pytest.mark.asyncio
+async def test_caller_settings_override_per_key(fake_client: _FakeClient) -> None:
+    await ch_client.execute_async(fake_client, "SELECT 1", settings={"max_memory_usage": 123, "readonly": 1})
+
+    applied = fake_client.calls[-1]["kwargs"]["settings"]
+    # caller wins per-key
+    assert applied["max_memory_usage"] == 123
+    # caller-only keys are merged in
+    assert applied["readonly"] == 1
+    # untouched defaults remain
+    assert applied["max_execution_time"] == settings.clickhouse_query_max_execution_time
+
+
+@pytest.mark.asyncio
+async def test_limits_can_be_disabled(fake_client: _FakeClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "clickhouse_query_max_memory_usage", 0)
+    monkeypatch.setattr(settings, "clickhouse_query_max_bytes_before_external_group_by", 0)
+    monkeypatch.setattr(settings, "clickhouse_query_max_execution_time", 0)
+
+    await ch_client.execute_async(fake_client, "SELECT 1")
+
+    assert fake_client.calls[-1]["kwargs"]["settings"] == {}


### PR DESCRIPTION
closes #563

### problem

`GET /v4/data/network/NEM` 500'd because clickhouse hit its server-wide memory cap (`Code: 241`, ~28 GiB) while running the data api aggregation. api queries (`get_timeseries_query` -> `execute_async`) had **no per-query memory limits**, so a wide date-range / fine-interval / multi-dimension request grows its GROUP BY hash table until the whole server is out of memory and the overcommit tracker kills a query. that can take out *unrelated* concurrent queries, so it's an availability bug, not just a slow request.

### fix

apply conservative, env-configurable per-query ch settings by default in `execute_async` (the serving path):

- `max_memory_usage` (default 8 GiB) - a single runaway query fails cleanly with its own error instead of killing the server
- `max_bytes_before_external_group_by` (default 4 GiB, ~half of max_memory_usage) - large GROUP BYs spill to disk and still complete
- `max_execution_time` (default 90s) - bounds runaways

callers can override any limit per-key via `settings={...}`. each limit set to `0` disables it. backfills/aggregations use the sync client directly and are unaffected.

### notes

- defaults are tunable via env (`CLICKHOUSE_QUERY_MAX_MEMORY_USAGE`, etc) so ch-prod can be adjusted without a deploy
- the deeper cost here is `FROM unit_intervals FINAL` + double GROUP BY over 749M rows; serving coarse intervals from the daily/fueltech MVs and dropping FINAL is a separate follow-up (noted in #563)

### test

`tests/db/test_clickhouse_client.py` covers default application, per-key caller override, and the `0 = disable` path. ruff + pyright clean (no new errors).
