### PR TITLE
fix(db): retry postgres deadlocks on cms sync + facility_seen_range

### DIFF
--- a/opennem/cms/importer.py
+++ b/opennem/cms/importer.py
@@ -31,7 +31,7 @@ from opennem.clients.slack import slack_message
 from opennem.cms.queries import get_cms_facilities
 from opennem.cms.utils import strip_synthetic_prefix
 from opennem.core.networks import network_from_network_code
-from opennem.db import get_read_session, get_write_session
+from opennem.db import get_read_session, get_write_session, retry_on_deadlock
 from opennem.db.models.opennem import Facility, Unit
 from opennem.schema.facility import FacilitySchema
 from opennem.workers.facility_data_seen import update_facility_seen_range
@@ -73,6 +73,7 @@ async def get_database_facilities() -> list[Facility]:
     return facilities
 
 
+@retry_on_deadlock
 async def create_or_update_database_facility(facility: FacilitySchema, send_slack: bool = True, dry_run: bool = False) -> bool:
     """Create new database facilities from the CMS or update existing ones.
 
@@ -626,11 +627,18 @@ async def update_database_facilities_from_cms(
     # Track statistics and created facility codes
     created_count = 0
     updated_count = 0
+    error_count = 0
     created_facility_codes = []
 
-    # Process each facility
+    # Process each facility. Isolate per-facility failures so one bad/contended facility
+    # (e.g. a deadlock that survives retries) doesn't abort the sync for everything after it.
     for facility in sanity_facilities:
-        was_created = await create_or_update_database_facility(facility, send_slack=send_slack, dry_run=dry_run)
+        try:
+            was_created = await create_or_update_database_facility(facility, send_slack=send_slack, dry_run=dry_run)
+        except Exception as e:
+            error_count += 1
+            logger.error(f"Failed to sync facility {facility.code} from CMS: {e}")
+            continue
         if was_created:
             created_count += 1
             created_facility_codes.append(facility.code)
@@ -641,7 +649,9 @@ async def update_database_facilities_from_cms(
     if dry_run:
         logger.info(f"Dry run complete: Would create {created_count} facilities, update {updated_count} facilities")
     else:
-        logger.info(f"Sync complete: {created_count} facilities created, {updated_count} facilities updated")
+        logger.info(
+            f"Sync complete: {created_count} facilities created, {updated_count} facilities updated, {error_count} failed"
+        )
 
     # Update facility seen range for new facilities if any were created
     if created_count > 0 and not dry_run:

--- a/opennem/db/__init__.py
+++ b/opennem/db/__init__.py
@@ -13,10 +13,12 @@ from contextlib import asynccontextmanager
 
 import deprecation
 from asyncpg.connection import Connection as AsyncConnection
+from asyncpg.exceptions import DeadlockDetectedError
 from sqlalchemy import Engine, create_engine
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import declarative_base
 from sqlalchemy.pool import NullPool
+from tenacity import retry, retry_if_exception, stop_after_attempt, wait_random_exponential
 
 from opennem import settings
 from opennem.utils.version import get_version
@@ -24,6 +26,38 @@ from opennem.utils.version import get_version
 DeclarativeBase = declarative_base()
 
 logger = logging.getLogger("opennem.db")
+
+# Postgres deadlock SQLSTATE — see https://www.postgresql.org/docs/current/errcodes-appendix.html
+_PG_DEADLOCK_SQLSTATE = "40P01"
+
+
+def is_deadlock_error(exc: BaseException) -> bool:
+    """True if exc, or anything in its cause chain, is a Postgres deadlock (SQLSTATE 40P01).
+
+    Deadlocks surface either as a raw ``asyncpg.DeadlockDetectedError`` or wrapped in a
+    SQLAlchemy ``DBAPIError`` (e.g. when raised during an autoflush), so we walk the chain
+    rather than matching a single exception type.
+    """
+    seen: set[int] = set()
+    cur: BaseException | None = exc
+    while cur is not None and id(cur) not in seen:
+        seen.add(id(cur))
+        if isinstance(cur, DeadlockDetectedError):
+            return True
+        if getattr(cur, "sqlstate", None) == _PG_DEADLOCK_SQLSTATE or getattr(cur, "pgcode", None) == _PG_DEADLOCK_SQLSTATE:
+            return True
+        cur = cur.__cause__ or getattr(cur, "orig", None)
+    return False
+
+
+# Decorator: retry an async write on Postgres deadlock with jittered exponential backoff.
+# The wrapped callable must own its session/transaction so each attempt starts clean.
+retry_on_deadlock = retry(
+    retry=retry_if_exception(is_deadlock_error),
+    stop=stop_after_attempt(4),
+    wait=wait_random_exponential(multiplier=0.2, max=5),
+    reraise=True,
+)
 
 _engine = None
 _engine_sync = None

--- a/opennem/workers/facility_data_seen.py
+++ b/opennem/workers/facility_data_seen.py
@@ -13,7 +13,7 @@ from textwrap import dedent
 
 from sqlalchemy import TextClause, text
 
-from opennem.db import db_connect
+from opennem.db import db_connect, retry_on_deadlock
 from opennem.queries.utils import duid_to_case
 from opennem.utils.dates import get_today_opennem
 
@@ -64,6 +64,7 @@ def get_update_seen_query(
 
 
 # @profile_task(send_slack=True)
+@retry_on_deadlock
 async def update_facility_seen_range(
     include_first_seen: bool = False,
     facility_codes: list[str] | None = None,

--- a/tests/db/test_deadlock_retry.py
+++ b/tests/db/test_deadlock_retry.py
@@ -1,0 +1,73 @@
+"""Tests for the Postgres deadlock detection predicate and retry decorator."""
+
+import pytest
+from asyncpg.exceptions import DeadlockDetectedError
+
+from opennem.db import is_deadlock_error, retry_on_deadlock
+
+
+class _FakeOrig(Exception):
+    """Stand-in for a DBAPI error exposing a sqlstate, like asyncpg adapters do."""
+
+    def __init__(self, sqlstate: str) -> None:
+        super().__init__("dbapi error")
+        self.sqlstate = sqlstate
+
+
+def test_raw_deadlock_is_detected() -> None:
+    assert is_deadlock_error(DeadlockDetectedError("deadlock detected")) is True
+
+
+def test_wrapped_deadlock_via_cause_chain_is_detected() -> None:
+    # mimics sqlalchemy DBAPIError -> __cause__ -> asyncpg DeadlockDetectedError (the autoflush case)
+    wrapper = RuntimeError("autoflush failed")
+    wrapper.__cause__ = DeadlockDetectedError("deadlock detected")
+    assert is_deadlock_error(wrapper) is True
+
+
+def test_sqlstate_on_orig_is_detected() -> None:
+    err = Exception("wrapped")
+    err.orig = _FakeOrig("40P01")  # type: ignore[attr-defined]
+    assert is_deadlock_error(err) is True
+
+
+def test_non_deadlock_is_not_detected() -> None:
+    assert is_deadlock_error(ValueError("nope")) is False
+    assert is_deadlock_error(_FakeOrig("23505")) is False  # unique_violation, not a deadlock
+
+
+def test_cause_cycle_terminates() -> None:
+    a = Exception("a")
+    b = Exception("b")
+    a.__cause__ = b
+    b.__cause__ = a  # self-referential chain must not loop forever
+    assert is_deadlock_error(a) is False
+
+
+@pytest.mark.asyncio
+async def test_retry_on_deadlock_retries_then_succeeds() -> None:
+    calls = {"n": 0}
+
+    @retry_on_deadlock
+    async def flaky() -> str:
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise DeadlockDetectedError("deadlock detected")
+        return "ok"
+
+    assert await flaky() == "ok"
+    assert calls["n"] == 3
+
+
+@pytest.mark.asyncio
+async def test_retry_on_deadlock_does_not_retry_other_errors() -> None:
+    calls = {"n": 0}
+
+    @retry_on_deadlock
+    async def boom() -> None:
+        calls["n"] += 1
+        raise ValueError("not a deadlock")
+
+    with pytest.raises(ValueError):
+        await boom()
+    assert calls["n"] == 1


### PR DESCRIPTION
closes #565

fixes three sentry issues with one root cause: [BACKEND-52F](https://opennem.sentry.io/issues/BACKEND-52F), [BACKEND-5F6](https://opennem.sentry.io/issues/BACKEND-5F6), [BACKEND-5FB](https://opennem.sentry.io/issues/BACKEND-5FB).

### problem

`task_update_facility_seen_range` runs a wide `UPDATE units SET data_first_seen/data_last_seen ...` and `task_refresh_from_cms` updates the same rows per-facility. when they overlap, postgres aborts one with `DeadlockDetectedError` (sqlstate 40P01).

- `52F` is the deadlock raised in `update_facility_seen_range`
- `5F6` is the *same* deadlock, but raised during a sqlalchemy autoflush inside `create_or_update_database_facility`, so it shows up wrapped as a generic `DBAPIError`
- `5FB` is the `PendingRollbackError` you get afterwards from reusing the aborted session

neither path retried, and the cms loop had no per-facility isolation, so one deadlock aborted the **entire** sync run.

### fix

- new reusable `retry_on_deadlock` decorator + `is_deadlock_error` predicate in `opennem/db`. the predicate walks the exception cause chain and matches both the raw `asyncpg.DeadlockDetectedError` and the sqlalchemy-wrapped form (via sqlstate `40P01`), so it works whether the deadlock surfaces directly or through an autoflush
- applied to `update_facility_seen_range` and `create_or_update_database_facility`. both own their transaction, so a retry starts from a fresh session; the cms function is idempotent (keyed on `cms_id`) so re-running is safe
- `update_database_facilities_from_cms` now isolates per-facility failures: a facility that still fails after retries is logged and skipped instead of aborting the whole sync (summary now reports a failed count)

backoff is jittered exponential, 4 attempts.

### test

`tests/db/test_deadlock_retry.py`: predicate detects raw / cause-chained / sqlstate-on-orig deadlocks, ignores non-deadlocks, terminates on cyclic cause chains; decorator retries-then-succeeds on deadlock and does not retry other errors. ruff clean, no new pyright errors.

### note

deadlock is inherent to two concurrent writers on shared rows; retry is the pragmatic remedy. de-conflicting the two task schedules is a possible follow-up but not needed here.
