### PR TITLE
fix(cms): retry transient sanity errors in get_cms_facilities

### DIFF
--- a/opennem/cms/queries.py
+++ b/opennem/cms/queries.py
@@ -30,6 +30,7 @@ from typing import TypeVar
 from portabletext_html import PortableTextRenderer
 from pydantic import ValidationError
 from sanity import SanityAsyncClient
+from sanity.exceptions import SanityConnectionError, SanityRateLimitError, SanityServerError, SanityTimeoutError
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 from opennem import settings
@@ -255,10 +256,24 @@ def _validate_unique_codes(facilities: list[FacilitySchema]) -> list[FacilitySch
     return filtered_facilities
 
 
+# Transient CMS errors worth retrying. The sanity client raises its own exception types
+# (not our wrappers) on network/cdn blips, so they must be in the retry predicate or a
+# single connect timeout aborts the whole sync. Non-transient sanity errors (auth,
+# not-found, validation) are intentionally excluded so we fail fast on those.
+_CMS_RETRYABLE_ERRORS = (
+    CMSQueryError,
+    ValidationError,
+    SanityTimeoutError,
+    SanityConnectionError,
+    SanityServerError,
+    SanityRateLimitError,
+)
+
+
 @retry(
     stop=stop_after_attempt(3),
     wait=wait_exponential(multiplier=1, min=4, max=10),
-    retry=retry_if_exception_type((CMSQueryError, ValidationError)),
+    retry=retry_if_exception_type(_CMS_RETRYABLE_ERRORS),
     reraise=True,
 )
 async def get_cms_facilities(facility_code: str | None = None, cms_id: str | None = None) -> list[FacilitySchema]:

--- a/tests/test_cms_retry.py
+++ b/tests/test_cms_retry.py
@@ -1,0 +1,25 @@
+"""Tests for the CMS query retry predicate (transient sanity errors must be retried)."""
+
+from sanity.exceptions import (
+    SanityAuthError,
+    SanityConnectionError,
+    SanityNotFoundError,
+    SanityRateLimitError,
+    SanityServerError,
+    SanityTimeoutError,
+    SanityValidationError,
+)
+
+from opennem.cms.queries import _CMS_RETRYABLE_ERRORS
+
+
+def test_transient_sanity_errors_are_retryable() -> None:
+    # these are the network/cdn blips that previously aborted the whole cms sync (BACKEND-5C0)
+    for exc in (SanityTimeoutError, SanityConnectionError, SanityServerError, SanityRateLimitError):
+        assert issubclass(exc, _CMS_RETRYABLE_ERRORS), f"{exc.__name__} should be retryable"
+
+
+def test_non_transient_sanity_errors_are_not_retryable() -> None:
+    # auth / not-found / bad-query are not transient — fail fast instead of hammering the cms
+    for exc in (SanityAuthError, SanityNotFoundError, SanityValidationError):
+        assert not issubclass(exc, _CMS_RETRYABLE_ERRORS), f"{exc.__name__} should not be retryable"


### PR DESCRIPTION
closes #567

fixes [BACKEND-5C0](https://opennem.sentry.io/issues/BACKEND-5C0) (540+ events, the noisiest backend error).

### problem

`task_refresh_from_cms` -> `get_cms_facilities` fails with `SanityTimeoutError` (underlying `ConnectTimeout` to sanity's query cdn). it's already wrapped in tenacity retry, but the predicate only matched our own wrapper types:

```python
retry=retry_if_exception_type((CMSQueryError, ValidationError))
```

the sanity client raises `sanity.exceptions.SanityTimeoutError`, which isn't in that tuple, so a single connect-timeout blip propagated on the first attempt and aborted the whole sync.

### fix

retry the transient sanity errors too (`SanityTimeoutError`, `SanityConnectionError`, `SanityServerError`, `SanityRateLimitError`) via the existing backoff. non-transient ones (`SanityAuthError`, `SanityNotFoundError`, `SanityValidationError`) stay out so we still fail fast on real problems.

### test

`tests/test_cms_retry.py` asserts the transient sanity errors are in the retry set and the non-transient ones are not. ruff clean, no new pyright errors.
