### PR TITLE
fix(exporter): add boto retry config to r2 client

### DIFF
--- a/opennem/exporter/storage_bucket.py
+++ b/opennem/exporter/storage_bucket.py
@@ -22,12 +22,19 @@ from datetime import datetime
 from zoneinfo import ZoneInfo
 
 import aioboto3
+from botocore.config import Config
 from botocore.exceptions import ClientError
 from humanize import naturalsize, naturaltime
 
 from opennem import settings
 
 logger = logging.getLogger("opennem.storage_bucket")
+
+# Retry config for the R2/S3 client. The default (legacy) retry mode retries few
+# conditions and gives up quickly, so transient `InternalError` (s3 500) responses from
+# R2 surface as failed uploads and abort exports. "standard" mode retries 5xx /
+# throttling / InternalError with exponential backoff.
+_S3_RETRY_CONFIG = Config(retries={"max_attempts": 10, "mode": "standard"})
 
 
 @dataclass
@@ -112,6 +119,7 @@ class CloudflareR2Uploader:
             aws_access_key_id=self.access_key_id,
             aws_secret_access_key=self.secret_access_key,
             region_name=self.region,
+            config=_S3_RETRY_CONFIG,
         )
 
     async def upload_file(

--- a/tests/exports/test_storage_bucket_retry.py
+++ b/tests/exports/test_storage_bucket_retry.py
@@ -1,0 +1,27 @@
+"""The R2 uploader must build its client with a retry config so transient
+InternalError (s3 500) responses are retried instead of aborting exports."""
+
+import pytest
+
+from opennem.exporter.storage_bucket import _S3_RETRY_CONFIG, CloudflareR2Uploader
+
+
+def test_retry_config_uses_standard_mode_with_extra_attempts() -> None:
+    assert _S3_RETRY_CONFIG.retries["mode"] == "standard"
+    assert _S3_RETRY_CONFIG.retries["max_attempts"] >= 5
+
+
+@pytest.mark.asyncio
+async def test_client_is_created_with_retry_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict = {}
+
+    class _FakeSession:
+        def client(self, **kwargs):  # noqa: ANN003, ANN201
+            captured.update(kwargs)
+            return object()
+
+    monkeypatch.setattr("opennem.exporter.storage_bucket.aioboto3.Session", lambda: _FakeSession())
+
+    await CloudflareR2Uploader()._get_s3_client()
+
+    assert captured["config"] is _S3_RETRY_CONFIG


### PR DESCRIPTION
closes #569

fixes [BACKEND-5DB](https://opennem.sentry.io/issues/BACKEND-5DB), [BACKEND-5FN](https://opennem.sentry.io/issues/BACKEND-5FN), [BACKEND-5DC](https://opennem.sentry.io/issues/BACKEND-5DC).

### problem

uploads to r2 occasionally fail with `InternalError` (s3 500) on `PutObject` during exports (`task_nem_interval_check`, `task_export_energy`). `CloudflareR2Uploader` logs and re-raises, so a transient blip aborts the export step.

`_get_s3_client` created the aioboto3 client with **no retry config**, so it used botocore's legacy retry mode (few attempts, narrow retryable set) and gave up.

### fix

build the client with an explicit `Config(retries={"max_attempts": 10, "mode": "standard"})`. standard mode retries 5xx / `InternalError` / throttling with exponential backoff, covering all bucket ops (upload_file/bytes/content, list_directory).

### test

`tests/exports/test_storage_bucket_retry.py`: asserts the retry config is standard-mode with extra attempts and that the client is actually created with it. ruff + pyright clean.
