### PR TITLE
fix(api): renewable_proportion returns null not 0 when demand_gross absent

### DIFF
--- a/opennem/api/queries.py
+++ b/opennem/api/queries.py
@@ -177,13 +177,18 @@ MARKET_METRIC_PLANS: dict[Metric, MetricPlan] = {
         outer="round(sum(energy_exports_sum_inner), 6)",
     ),
     # Proportions: sum the underlying components across the bucket, then divide.
+    # NULL (not 0) when demand_gross is absent for the bucket. The freshest/settling
+    # interval can be served before demand_gross lands (generation_renewable and
+    # demand_gross arrive on different paths), and a literal-0 fallback produced a
+    # spurious 0% that "healed" on the next poll (#575). NULL serialises to `null`,
+    # signalling "not yet available" rather than a non-physical 0%.
     Metric.RENEWABLE_PROPORTION: MetricPlan(
         inner={"gr_sum_inner": "sum(generation_renewable)", "dg_sum_inner": "sum(demand_gross)"},
-        outer="round(if(sum(dg_sum_inner) > 0, (sum(gr_sum_inner) / sum(dg_sum_inner)) * 100, 0), 2)",
+        outer="if(sum(dg_sum_inner) > 0, round((sum(gr_sum_inner) / sum(dg_sum_inner)) * 100, 2), NULL)",
     ),
     Metric.RENEWABLE_WITH_STORAGE_PROPORTION: MetricPlan(
         inner={"grws_sum_inner": "sum(generation_renewable_with_storage)", "dg_sum_inner": "sum(demand_gross)"},
-        outer="round(if(sum(dg_sum_inner) > 0, (sum(grws_sum_inner) / sum(dg_sum_inner)) * 100, 0), 2)",
+        outer="if(sum(dg_sum_inner) > 0, round((sum(grws_sum_inner) / sum(dg_sum_inner)) * 100, 2), NULL)",
     ),
 }
 

--- a/tests/api/test_queries_renewable_proportion.py
+++ b/tests/api/test_queries_renewable_proportion.py
@@ -1,0 +1,37 @@
+"""Lock the renewable-proportion SQL to emit NULL (not 0) when demand_gross is absent.
+
+Regression for opennem#575: the freshest/settling interval could be served before
+demand_gross landed, and the old `if(sum(dg) > 0, ..., 0)` fallback produced a spurious
+0% renewable_proportion that "healed" on the next poll. The proportion must instead
+return NULL so it serialises to `null` ("not yet available"), never a non-physical 0%.
+"""
+
+from datetime import datetime
+
+import pytest
+
+from opennem.api.queries import QueryType, get_timeseries_query
+from opennem.core.metric import Metric
+from opennem.core.time_interval import Interval
+from opennem.schema.network import NetworkNEM
+
+
+@pytest.mark.parametrize("metric", [Metric.RENEWABLE_PROPORTION, Metric.RENEWABLE_WITH_STORAGE_PROPORTION])
+def test_proportion_returns_null_not_zero_when_demand_gross_absent(metric):
+    """The else-branch of the proportion guard must be NULL, never a literal 0."""
+    sql, _, _ = get_timeseries_query(
+        query_type=QueryType.MARKET,
+        network=NetworkNEM,
+        metrics=[metric],
+        interval=Interval.INTERVAL,
+        date_start=datetime(2026, 6, 16, 0, 0),
+        date_end=datetime(2026, 6, 17, 0, 0),
+        network_region="VIC1",
+    )
+    out = f"{metric.value.lower()}"
+    # guarded division still present
+    assert "if(sum(dg_sum_inner) > 0," in sql
+    # else-branch is NULL, and the metric column is emitted
+    assert f", NULL) AS {out}" in sql
+    # the old spurious-0 fallback must be gone
+    assert f", 0), 2) AS {out}" not in sql


### PR DESCRIPTION
## What

The v4 market/data API intermittently served a spurious `0` for `renewable_proportion` on the most-recent / settling 5-min interval, which then "healed" on a subsequent fetch. Reported in #575 (VIC1 examples: `[45.35, 0, 45.23]`, `[45.77, 0, 39.51]`).

## Root cause

`opennem/api/queries.py` — the proportion metric plans guarded the division with an `if(...,0)` fallback:

```sql
round(if(sum(demand_gross) > 0, (sum(generation_renewable)/sum(demand_gross))*100, 0), 2)
```

The served upper bound is pure wall-clock (`get_last_completed_interval_for_network`), with no completeness check, so the freshest interval can be queried before `demand_gross` lands. `generation_renewable` and `demand_gross` are written on different paths in the market_summary aggregate — when renewables arrive a beat before demand_gross, the denominator is NULL/0, the fallback fires, and the API returns a non-physical `0%`. Next poll, demand_gross arrives → recomputes correctly = the "healing".

## Fix

Return `NULL` (not `0`) when `demand_gross` is absent, so the value serialises to `null` — "not yet available" rather than a non-physical 0%. This is exactly the behaviour requested in #575 Q3. Applied to both `renewable_proportion` and `renewable_with_storage_proportion`.

```sql
if(sum(demand_gross) > 0, round((sum(generation_renewable)/sum(demand_gross))*100, 2), NULL)
```

## Test

`tests/api/test_queries_renewable_proportion.py` locks the else-branch to `NULL` for both proportion metrics and asserts the old `, 0), 2)` fallback is gone.

## Not in scope (follow-ups for #575)

- **emissions** reads `0` for the settling interval via the same incomplete-interval root cause but a different mechanism (`sum()` over not-yet-computed emissions) — needs a separate look.
- **price** `0`s are genuine (zero/negative spot prices); it already returns `null` when absent. Not a bug.
- No `is_final` / settlement flag in the response schema (#575 Q2) — separate enhancement.

Refs #575