### PR TITLE
fix(api): exclude provisional bleeding-edge interval from live v4 responses

### DIFF
--- a/opennem/api/data/router.py
+++ b/opennem/api/data/router.py
@@ -12,6 +12,7 @@ from fastapi_cache.decorator import cache
 from fastapi_versionizer import api_version
 
 from opennem.api.data.utils import validate_date_range
+from opennem.api.intervals import cap_date_end_to_settled_interval
 from opennem.api.queries import QueryType, get_timeseries_query
 from opennem.api.schema import std_error_responses
 from opennem.api.security import authenticated_user, optional_user
@@ -92,12 +93,20 @@ async def get_network_data(
     network = get_api_network_from_code(network_code)
     validate_metrics(metrics, _SUPPORTED_METRICS)
 
+    live_query = date_end is None
+
     date_start, date_end = validate_date_range(
         network=network, user=user, interval=interval, date_start=date_start, date_end=date_end
     )
 
     if date_start > date_end:
         raise HTTPException(status_code=400, detail="Date start must be before date end")
+
+    # Live request: don't serve the provisional bleeding-edge interval (#575).
+    if live_query:
+        date_end = await cap_date_end_to_settled_interval(
+            client=client, network=network, query_type=QueryType.DATA, date_end=date_end
+        )
 
     secondary_groupings = [secondary_grouping] if secondary_grouping else None
 
@@ -205,9 +214,17 @@ async def get_facility_data(
     network = get_api_network_from_code(network_code)
     validate_metrics(metrics, _SUPPORTED_METRICS)
 
+    live_query = date_end is None
+
     date_start, date_end = validate_date_range(
         network=network, user=user, interval=interval, date_start=date_start, date_end=date_end
     )
+
+    # Live request: don't serve the provisional bleeding-edge interval (#575).
+    if live_query:
+        date_end = await cap_date_end_to_settled_interval(
+            client=client, network=network, query_type=QueryType.FACILITY, date_end=date_end
+        )
 
     if facility_code and len(facility_code) > 30:
         raise HTTPException(status_code=400, detail="Facility code list must have fewer than 30 entries")

--- a/opennem/api/intervals.py
+++ b/opennem/api/intervals.py
@@ -1,0 +1,89 @@
+"""Determine the latest fully-settled interval for the live v4 data/market endpoints.
+
+The most-recent interval present in ClickHouse is provisional: AEMO data for it can
+still be settling when the aggregate first writes it, which surfaced as spurious `0`s
+(emissions, renewable_proportion) that "heal" on a later poll (#575).
+
+We treat `max(interval)` as an EXCLUSIVE upper bound. Combined with the query's
+`interval < date_end`, this serves only intervals that already have a newer interval
+behind them — i.e. intervals that have settled — and never the bleeding edge. Genuinely
+absent trailing intervals are already omitted by the GROUP BY; this additionally drops
+the present-but-provisional latest interval.
+
+Only applied to the live case (no explicit `date_end`); explicit historical ranges are
+left untouched. Falls back to the caller's `date_end` on empty table / CH error so the
+endpoints never break.
+"""
+
+import logging
+import time
+from datetime import datetime
+from typing import Any
+
+from opennem.api.queries import QUERY_CONFIGS, QueryType
+from opennem.db.clickhouse import execute_async
+from opennem.schema.network import NetworkSchema
+
+logger = logging.getLogger("opennem.api.intervals")
+
+# max(interval) only advances once per interval_size minutes, so a short TTL spares a CH
+# round-trip on every (cache-missed) request without serving a meaningfully stale bound.
+_CACHE_TTL_SECONDS = 30
+_latest_interval_cache: dict[tuple[str, str], tuple[float, datetime | None]] = {}
+
+
+async def _get_latest_interval(client: Any, network: NetworkSchema, base_table: str) -> datetime | None:
+    """Latest interval present in `base_table` for `network`, or None on empty/error.
+
+    Scoped to the last 7 days so the query stays bounded against the (interval-first)
+    primary key while still covering WEM, which publishes ~24h late. `max()` needs no
+    FINAL — dedup is irrelevant to the maximum timestamp. A table with no rows in the
+    window (a multi-day ingestion outage) returns None and the caller falls back to its
+    own date_end; that is harmless because such a table has no bleeding edge to exclude.
+    """
+    cache_key = (base_table, network.code)
+    monotonic_now = time.monotonic()
+    cached = _latest_interval_cache.get(cache_key)
+    if cached is not None and cached[0] > monotonic_now:
+        return cached[1]
+
+    query = (
+        f"SELECT max(interval) FROM {base_table} "  # noqa: S608 — base_table is an internal enum-derived constant
+        "WHERE network_id IN %(network)s AND interval > now() - INTERVAL 7 DAY"
+    )
+    try:
+        rows = await execute_async(client, query, {"network": tuple(network.get_network_codes())})
+        latest = rows[0][0] if rows and rows[0][0] is not None else None
+    except Exception as e:
+        logger.warning(f"could not determine latest {base_table} interval for {network.code}: {e}")
+        latest = None
+
+    # `interval` is DateTime64(3) (naive) today; strip tz defensively so a future
+    # 'UTC'-tagged column can't make min() raise on naive-vs-aware date_end.
+    if latest is not None and latest.tzinfo is not None:
+        latest = latest.replace(tzinfo=None)
+
+    _latest_interval_cache[cache_key] = (monotonic_now + _CACHE_TTL_SECONDS, latest)
+    return latest
+
+
+async def cap_date_end_to_settled_interval(
+    client: Any,
+    network: NetworkSchema,
+    query_type: QueryType,
+    date_end: datetime,
+) -> datetime:
+    """Cap an exclusive-upper-bound `date_end` at the latest settled interval.
+
+    Returns `date_end` unchanged only when the table is empty / on CH error. Otherwise
+    caps at `max(interval)` unconditionally — with the query's `interval < date_end` this
+    excludes the provisional latest interval. If the caller's window sat entirely on the
+    bleeding edge (date_start >= the settled boundary) the query returns no rows and the
+    endpoint 404s, which is the correct answer: an empty range beats serving a value we
+    know is still settling.
+    """
+    base_table = QUERY_CONFIGS[query_type].base_table
+    latest = await _get_latest_interval(client, network, base_table)
+    if latest is None:
+        return date_end
+    return min(date_end, latest)

--- a/opennem/api/market/router.py
+++ b/opennem/api/market/router.py
@@ -12,6 +12,7 @@ from fastapi_cache.decorator import cache
 from fastapi_versionizer import api_version
 
 from opennem.api.data.utils import validate_date_range
+from opennem.api.intervals import cap_date_end_to_settled_interval
 from opennem.api.queries import QueryType, get_timeseries_query
 from opennem.api.schema import std_error_responses
 from opennem.api.security import optional_user
@@ -98,12 +99,20 @@ async def get_network_data(
     if network_region:
         primary_grouping = PrimaryGrouping.NETWORK_REGION
 
+    live_query = date_end is None
+
     date_start, date_end = validate_date_range(
         network=network, user=user, interval=interval, date_start=date_start, date_end=date_end
     )
 
     if date_start > date_end:
         raise HTTPException(status_code=400, detail="Date start must be before date end")
+
+    # Live request: don't serve the provisional bleeding-edge interval (#575).
+    if live_query:
+        date_end = await cap_date_end_to_settled_interval(
+            client=client, network=network, query_type=QueryType.MARKET, date_end=date_end
+        )
 
     query, params, column_names = get_timeseries_query(
         query_type=QueryType.MARKET,

--- a/tests/api/test_intervals_cap.py
+++ b/tests/api/test_intervals_cap.py
@@ -1,0 +1,115 @@
+"""The live v4 endpoints must cap date_end at the latest settled interval so the
+provisional bleeding-edge interval is never served (#575).
+
+`cap_date_end_to_settled_interval` treats max(interval) as an exclusive upper bound
+(the query uses `interval < date_end`), with safe fallbacks on empty/error/inverted
+ranges.
+"""
+
+from datetime import datetime
+
+import pytest
+
+import opennem.api.intervals as intervals
+from opennem.api.intervals import cap_date_end_to_settled_interval
+from opennem.api.queries import QueryType
+from opennem.schema.network import NetworkNEM
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    intervals._latest_interval_cache.clear()
+    yield
+    intervals._latest_interval_cache.clear()
+
+
+def _fake_execute_returning(value):
+    async def _fake(client, query, params):  # noqa: ANN001, ANN202
+        return [[value]]
+
+    return _fake
+
+
+@pytest.mark.asyncio
+async def test_caps_to_latest_when_data_lags_wall_clock(monkeypatch):
+    latest = datetime(2026, 6, 22, 9, 45)
+    monkeypatch.setattr(intervals, "execute_async", _fake_execute_returning(latest))
+
+    capped = await cap_date_end_to_settled_interval(
+        client=object(),
+        network=NetworkNEM,
+        query_type=QueryType.DATA,
+        date_end=datetime(2026, 6, 22, 9, 55),  # wall-clock boundary, ahead of data
+    )
+    # capped to max(interval); `interval < date_end` then excludes the provisional latest
+    assert capped == latest
+
+
+@pytest.mark.asyncio
+async def test_returns_date_end_on_error(monkeypatch):
+    async def _boom(client, query, params):  # noqa: ANN001, ANN202
+        raise RuntimeError("clickhouse down")
+
+    monkeypatch.setattr(intervals, "execute_async", _boom)
+    date_end = datetime(2026, 6, 22, 9, 55)
+
+    capped = await cap_date_end_to_settled_interval(
+        client=object(),
+        network=NetworkNEM,
+        query_type=QueryType.MARKET,
+        date_end=date_end,
+    )
+    assert capped == date_end
+
+
+@pytest.mark.asyncio
+async def test_returns_date_end_on_empty_table(monkeypatch):
+    monkeypatch.setattr(intervals, "execute_async", _fake_execute_returning(None))
+    date_end = datetime(2026, 6, 22, 9, 55)
+
+    capped = await cap_date_end_to_settled_interval(
+        client=object(),
+        network=NetworkNEM,
+        query_type=QueryType.MARKET,
+        date_end=date_end,
+    )
+    assert capped == date_end
+
+
+@pytest.mark.asyncio
+async def test_caps_unconditionally_even_on_bleeding_edge_window(monkeypatch):
+    """A live window sitting entirely on the bleeding edge still caps at the settled
+    boundary — the caller's query then yields no rows (404) rather than the known-bad
+    provisional interval."""
+    latest = datetime(2026, 6, 22, 9, 45)
+    monkeypatch.setattr(intervals, "execute_async", _fake_execute_returning(latest))
+
+    capped = await cap_date_end_to_settled_interval(
+        client=object(),
+        network=NetworkNEM,
+        query_type=QueryType.DATA,
+        date_end=datetime(2026, 6, 22, 9, 55),
+    )
+    assert capped == latest
+
+
+@pytest.mark.asyncio
+async def test_result_is_cached_within_ttl(monkeypatch):
+    latest = datetime(2026, 6, 22, 9, 45)
+    calls = {"n": 0}
+
+    async def _counting(client, query, params):  # noqa: ANN001, ANN202
+        calls["n"] += 1
+        return [[latest]]
+
+    monkeypatch.setattr(intervals, "execute_async", _counting)
+    kwargs = {
+        "client": object(),
+        "network": NetworkNEM,
+        "query_type": QueryType.DATA,
+        "date_end": datetime(2026, 6, 22, 9, 55),
+    }
+
+    await cap_date_end_to_settled_interval(**kwargs)
+    await cap_date_end_to_settled_interval(**kwargs)
+    assert calls["n"] == 1  # second call served from the TTL cache


### PR DESCRIPTION
## What

Follow-up to #576 covering the **emissions** half of #575 (and any other metric on the freshest interval).

The v4 served a spurious `0` for the most-recent / settling 5-min interval (emissions, renewable_proportion, …) which then "healed" on a later poll. #576 fixed `renewable_proportion` at the SQL level, but **emissions** can't be fixed that way — a genuinely renewable-heavy interval legitimately has near-zero emissions, so `0` isn't distinguishable from "not settled yet" by value alone.

## Root cause

The served upper bound (`date_end`) was pure wall-clock (`get_last_completed_interval_for_network`) with **no completeness check**, so the bleeding-edge interval got served before AEMO data for it settled. (`emissions`/`energy` are written atomically per `unit_intervals` row, but the freshest interval can be aggregated from a partial dispatch publish and is rewritten as more lands.)

## Fix

Per @nc9's suggestion in #575: **don't serve intervals that haven't settled yet**, default stays `null`.

Cap the live `date_end` at `max(interval)` present in the relevant ClickHouse base table. With the query's existing strict `interval < date_end`, this serves only intervals that already have a newer interval behind them — i.e. settled ones — and never the bleeding edge. Genuinely-missing values within served intervals stay `null` (unchanged).

- New helper `opennem/api/intervals.py::cap_date_end_to_settled_interval` (per-table via `QUERY_CONFIGS`, 30s TTL cache, 7-day-scoped `max(interval)`, no `FINAL`).
- Wired into the three live endpoints: market `/network`, data `/network`, data `/facilities`.
- **Only** applies when the caller omits `date_end` (live case); explicit historical ranges are untouched.
- Fails safe: empty table / CH error → returns the caller's `date_end` unchanged, so endpoints never break.

## Behaviour change / tradeoff

Live responses now end one interval earlier (the latest aggregated interval is treated as provisional). For a status/analytics API where the last 5-min interval is inherently provisional in NEM, correct-but-one-interval-behind beats a non-physical `0`. A window sitting entirely on the bleeding edge now 404s (no settled data yet) rather than returning a provisional value — the intended semantic.

## Review

Codex-reviewed; addressed its medium finding (cap unconditionally rather than guarding against range inversion, so a narrow bleeding-edge window can't reopen the bug) and widened the scan window 3→7 days. Intentionally did **not** adopt min-of-per-network-maxima — for `unit_intervals` the overall max is NEM's 5-min cadence, which is correct for emissions; min-of-maxima would needlessly wait on 30-min rooftop.

## Tests

`tests/api/test_intervals_cap.py` — caps when data lags, fail-safe on error/empty, unconditional cap on bleeding-edge window, TTL cache hit.

Closes #575