### PR TITLE
fix(social): pass --no-sandbox to html2image + harden milestone social loop

### DIFF
--- a/opennem/recordreactor/incremental.py
+++ b/opennem/recordreactor/incremental.py
@@ -40,6 +40,10 @@ logger = logging.getLogger("opennem.recordreactor.incremental")
 
 _DEFAULT_NETWORKS = [NetworkNEM, NetworkWEM]
 
+# Cap social submissions per run so a day-boundary burst doesn't flood the approval
+# queue. Most significant first; anything dropped is logged (not silent).
+_MAX_SOCIAL_POSTS_PER_RUN = 10
+
 _DEFAULT_PERIODS = [
     MilestonePeriod.interval,
     MilestonePeriod.day,
@@ -329,16 +333,28 @@ async def run_incremental_milestone_check(
 
     # Submit significant milestones to social media pipeline
     if significant_records:
-        try:
-            from sqlalchemy import and_, select
+        import asyncio as _asyncio
 
-            from opennem.db import get_read_session
-            from opennem.db.models.opennem import Milestones
-            from opennem.social.content import build_record_url, render_milestone_card, render_milestone_social_text
-            from opennem.social.pipeline import create_social_post
-            from opennem.social.schema import CreateSocialPostRequest, SocialPostType
+        from sqlalchemy import and_, select
 
-            for record in significant_records[:5]:
+        from opennem.db import get_read_session
+        from opennem.db.models.opennem import Milestones
+        from opennem.social.content import build_record_url, render_milestone_card, render_milestone_social_text
+        from opennem.social.pipeline import create_social_post
+        from opennem.social.schema import CreateSocialPostRequest, SocialPostType
+
+        # Most significant first; cap the per-run burst and log anything dropped.
+        ordered = sorted(significant_records, key=lambda r: r.significance, reverse=True)
+        to_post = ordered[:_MAX_SOCIAL_POSTS_PER_RUN]
+        if len(ordered) > _MAX_SOCIAL_POSTS_PER_RUN:
+            logger.warning(
+                f"Capping social submissions at {_MAX_SOCIAL_POSTS_PER_RUN}; "
+                f"dropping {len(ordered) - _MAX_SOCIAL_POSTS_PER_RUN} lower-significance records"
+            )
+
+        for record in to_post:
+            # Isolate each record so one render/upload failure doesn't drop the batch.
+            try:
                 text = render_milestone_social_text(record)
 
                 # Fetch the most recent 40 history records for the sparkline.
@@ -360,8 +376,6 @@ async def run_incremental_milestone_check(
                 history = [(r.interval, float(r.value)) for r in reversed(rows)]
 
                 # Render card image (run in thread — html2image is sync + slow)
-                import asyncio as _asyncio
-
                 image_bytes = await _asyncio.to_thread(
                     render_milestone_card,
                     record_id=record.record_id,
@@ -396,8 +410,8 @@ async def run_incremental_milestone_check(
                     ),
                     image=image_bytes,
                 )
-        except Exception as e:
-            logger.error(f"Failed to submit milestones to social pipeline: {e}")
+            except Exception as e:
+                logger.error(f"Failed to submit milestone {record.record_id} to social pipeline: {e}")
 
     if all_new_records:
         logger.info(f"Incremental check complete: {len(all_new_records)} new records ({len(significant_records)} significant)")

--- a/opennem/social/content.py
+++ b/opennem/social/content.py
@@ -53,6 +53,20 @@ def build_record_url(record_id: str, focus_ts_ms: int) -> str:
 
 # ---------- Image card ----------
 
+# Chromium flags for html2image rendering inside the (non-root) production container.
+# html2image REPLACES its own default flags when custom_flags is passed and never
+# injects --no-sandbox, so without these chromium can fail to launch as appuser in
+# the DO container and no PNG is written. Keep html2image's defaults
+# (--hide-scrollbars / --default-background-color) and add the container flags.
+# Append a per-call --force-device-scale-factor where needed.
+CHROMIUM_RENDER_FLAGS = [
+    "--no-sandbox",
+    "--disable-dev-shm-usage",
+    "--disable-gpu",
+    "--hide-scrollbars",
+    "--default-background-color=00000000",
+]
+
 CARD_WIDTH = 1200
 CARD_HEIGHT = 630
 SPARKLINE_VIEW_W = 1088  # 1200 - 2*56 card padding
@@ -274,11 +288,15 @@ def render_milestone_card(
     hti = Html2Image(
         output_path=output_dir,
         size=(CARD_WIDTH, CARD_HEIGHT),
-        custom_flags=["--force-device-scale-factor=2"],
+        custom_flags=[*CHROMIUM_RENDER_FLAGS, "--force-device-scale-factor=2"],
     )
     hti.screenshot(html_str=html, save_as=output_file)
 
     output_path = Path(output_dir) / output_file
+    # chromium failures are silent (no check=True in html2image) — surface them here
+    # with a clear error rather than a downstream FileNotFoundError.
+    if not output_path.exists():
+        raise RuntimeError(f"chromium failed to render milestone card {record_id} (no output at {output_path})")
     data = output_path.read_bytes()
     output_path.unlink(missing_ok=True)
 

--- a/opennem/workers/weekly_summary.py
+++ b/opennem/workers/weekly_summary.py
@@ -579,6 +579,8 @@ def plot_weekly_fueltech_summary(ws: WeeklySummary) -> io.BytesIO:
     """Render branded HTML summary and screenshot to PNG via headless Chrome."""
     from html2image import Html2Image
 
+    from opennem.social.content import CHROMIUM_RENDER_FLAGS
+
     top_records = [r for r in ws.records if r.energy_gwh >= 1][:8]
     max_energy = max((r.energy_gwh for r in top_records), default=1)
     display_records = [_prepare_record_display(r, max_energy) for r in top_records]
@@ -646,11 +648,16 @@ def plot_weekly_fueltech_summary(ws: WeeklySummary) -> io.BytesIO:
     hti = Html2Image(
         output_path=output_dir,
         size=(IMAGE_WIDTH, IMAGE_MAX_HEIGHT),
-        custom_flags=[f"--force-device-scale-factor={IMAGE_DPI_SCALE}"],
+        custom_flags=[*CHROMIUM_RENDER_FLAGS, f"--force-device-scale-factor={IMAGE_DPI_SCALE}"],
     )
     hti.screenshot(html_str=html, save_as=output_file)
 
     output_path = Path(output_dir) / output_file
+    # chromium failures are silent (no check=True in html2image) — surface them here.
+    if not output_path.exists():
+        raise RuntimeError(
+            f"chromium failed to render weekly summary {ws.network} wk{ws.week_number} (no output at {output_path})"
+        )
 
     # Crop to content — remove empty space at bottom
     from PIL import Image


### PR DESCRIPTION
closes #582

milestone -> social and weekly-summary -> social render a png via html2image (headless chromium) before submitting to the social pipeline. html2image 2.0.7 replaces its default flags when `custom_flags` is passed and never injects `--no-sandbox`, so chromium can silently fail to launch as the non-root `appuser` in the DO container -> no png written -> `read_bytes()` raises -> the broad try/except swallows it -> zero social posts, no alert.

rendering fine in prod right now, so this is a defensive/robustness fix not an active outage, but the failure mode is silent and has bitten us before.

### changes
- shared `CHROMIUM_RENDER_FLAGS` constant in `social/content.py` (`--no-sandbox --disable-dev-shm-usage --disable-gpu` + html2image's own `--hide-scrollbars`/`--default-background-color=00000000` defaults, which `custom_flags` would otherwise drop). used at both render sites (`render_milestone_card`, `plot_weekly_fueltech_summary`), each still appending its own `--force-device-scale-factor`.
- assert the screenshot file exists after `screenshot()` so a silent chromium failure surfaces as a clear `RuntimeError` instead of a downstream `FileNotFoundError`.
- harden the incremental social loop in `recordreactor/incremental.py`: per-record try/except so one render/upload failure no longer drops the whole batch; replace the silent `significant_records[:5]` cap with sort-by-significance-desc + a logged cap at 10.

### notes
- `Dockerfile` sets `ENV CHROMIUM_FLAGS="--no-sandbox ..."` but html2image doesn't read that env var (it was a no-op). left in place; harmless.
- no render-output change expected: both templates set an opaque body background, so keeping the transparent default-background flag doesn't alter visible output.

### test
- ruff check + format clean
- modules import; constant resolves
- codex review: no issues