### PR TITLE
fix(webhooks): sanity seen-range SQL alias + quiet expected webhook errors

### DIFF
--- a/opennem/api/webhooks/router.py
+++ b/opennem/api/webhooks/router.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, Request
 from fastapi.responses import Response
 from fastapi_versionizer.versionizer import api_version
 from pydantic import BaseModel, EmailStr
+from sanity.exceptions import SanityConnectionError, SanityRateLimitError, SanityServerError, SanityTimeoutError
 from sqlalchemy.exc import IntegrityError
 from starlette.exceptions import HTTPException
 
@@ -98,6 +99,10 @@ async def webhook_sanity_update(webhook_secret: str, request: Request) -> str:
         raise HTTPException(status_code=503, detail="Service temporarily unavailable") from e
     except IntegrityError as e:
         logger.warning(f"Sanity webhook skipped — DB constraint conflict (duplicate code?): {e}")
+    except (SanityTimeoutError, SanityConnectionError, SanityServerError, SanityRateLimitError) as e:
+        # already retried inside get_cms_facilities — this means the CMS CDN is still down
+        logger.warning(f"Sanity webhook skipped — CMS temporarily unavailable: {e}")
+        raise HTTPException(status_code=503, detail="Service temporarily unavailable") from e
     except Exception as e:
         logger.error(f"Error parsing sanity webhook: {e}")
         raise HTTPException(status_code=500, detail="Server Error") from e

--- a/opennem/controllers/sanity.py
+++ b/opennem/controllers/sanity.py
@@ -20,6 +20,9 @@ async def get_facility_cms_id_by_unit_cms_id(cms_id: str) -> str | None:
 
     This is used in the sanity webhook when a unit is updated. We need the parent facility
     code so we can run the job to sync it.
+
+    Returns None if no facility is found — this is expected when the webhook fires for a
+    unit that isn't linked to a facility in our DB yet (e.g. a new/draft unit in the CMS).
     """
     async with get_read_session() as session:
         query = select(Facility).join(Unit, Facility.id == Unit.station_id).where(Unit.cms_id == cms_id)
@@ -27,7 +30,7 @@ async def get_facility_cms_id_by_unit_cms_id(cms_id: str) -> str | None:
         record = result.scalars().one_or_none()
         if record:
             return record.cms_id
-        raise Exception(f"No facility found for unit cms_id: {cms_id}")
+        return None
 
 
 async def parse_sanity_webhook_request(request: dict) -> None:
@@ -51,6 +54,9 @@ async def parse_sanity_webhook_request(request: dict) -> None:
         await update_database_facilities_from_cms(cms_id=cms_id, send_slack=False)
     elif record_type == "unit":
         facility_cms_id = await get_facility_cms_id_by_unit_cms_id(cms_id)
+        if facility_cms_id is None:
+            logger.warning(f"No facility found for unit cms_id: {cms_id} — skipping sanity sync")
+            return
         await update_database_facilities_from_cms(cms_id=facility_cms_id, send_slack=False)
     else:
         logger.warning(f"Unhandled record type: {record_type}")

--- a/opennem/workers/facility_data_seen.py
+++ b/opennem/workers/facility_data_seen.py
@@ -51,7 +51,7 @@ def get_update_seen_query(
     """
 
     fs = "" if include_first_seen else "--"
-    facility_codes_query = f"and f.code in ({duid_to_case(facility_codes)})" if facility_codes else ""
+    facility_codes_query = f"and fs.facility_code in ({duid_to_case(facility_codes)})" if facility_codes else ""
 
     trading_interval_window = ""
 

--- a/tests/test_facility_seen_query.py
+++ b/tests/test_facility_seen_query.py
@@ -1,0 +1,21 @@
+"""Tests for the facility seen-range update query (BACKEND-51M/51N).
+
+The facility_codes filter previously referenced an alias "f" that was never joined in the
+query, so postgres raised `missing FROM-clause entry for table "f"` whenever the sanity
+webhook created a new facility (see opennem/workers/facility_data_seen.py).
+"""
+
+from opennem.workers.facility_data_seen import get_update_seen_query
+
+
+def test_facility_codes_filter_uses_facility_scada_alias() -> None:
+    query = str(get_update_seen_query(include_first_seen=True, facility_codes=["SMFBESS2"]))
+
+    assert "f.code in" not in query
+    assert "fs.facility_code in ('SMFBESS2')" in query
+
+
+def test_no_facility_codes_filter_when_not_provided() -> None:
+    query = str(get_update_seen_query(include_first_seen=True))
+
+    assert "facility_code in" not in query


### PR DESCRIPTION
closes #574

item 2 of #574 only. item 1 (dev `social_posts` migration) is handled separately by ops, not touched here.

the issue said these sentry clusters looked "last seen ~11 days ago" and just needed closing. checked each one directly in sentry first — they're not stale, still actively firing (51M/51N/51J/51K last seen 3 days ago, unresolved). so this fixes the actual root causes instead of just closing tickets.

## root causes

**BACKEND-51M/51N** — `missing FROM-clause entry for table "f"` (20/21 events). genuine query-builder bug in `update_facility_seen_range`'s SQL builder (`opennem/workers/facility_data_seen.py`): the facility_codes filter referenced alias `f`, but the subquery only aliases `facility_scada` as `fs`. fired every time the sanity webhook created a new facility. fixed `f.code` -> `fs.facility_code`. validated by running `EXPLAIN` on the generated SQL against dev (read-only) — plans clean now instead of erroring.

**BACKEND-51J/51K** — `No facility found for unit cms_id: ...` (333/387 events, by far the biggest cluster). `get_facility_cms_id_by_unit_cms_id` raised a bare exception whenever a sanity "unit" webhook fired for a unit not yet linked to a facility in our db — an expected condition given sanity is eventually consistent. this propagated to the router's generic exception handler as a 500/error-log, paging sentry for something routine. now returns `None` and the caller logs a warning + skips instead of raising.

**BACKEND-505/504** — sanity CDN timeouts/connection errors. `get_cms_facilities` already retries these (`SanityTimeoutError`/`SanityConnectionError`/`SanityServerError`/`SanityRateLimitError`) internally, but they don't subclass the builtin `TimeoutError`, so once retries were exhausted they fell through to the generic 500/error handler instead of the existing 503/warning path used for plain `TimeoutError`. added a dedicated except branch mirroring that. genuine sanity errors (auth/validation/not-found) are intentionally left alone so real failures still surface as errors.

## test plan
- [x] `uv run ruff format` / `uv run ruff check --fix` clean
- [x] added `tests/test_facility_seen_query.py` (source-guard style, no db) asserting the alias fix and guarding against regression — passes
- [x] validated corrected SQL via `EXPLAIN` against dev db (read-only)
- [x] codex review via `/review` skill: 5/5 ship, no issues