### PR TITLE
fix(export): snap rooftop forecast + generation windows to 30min grid

### DIFF
--- a/opennem/queries/power.py
+++ b/opennem/queries/power.py
@@ -116,25 +116,32 @@ def get_rooftop_forecast_generation_query(
     # so a window bound that lands off the 30-min grid (eg range.end at :45) leaves
     # the leading/trailing 5-min buckets null. Snap both bounds down to the 30-min
     # grid so gapfill always has an anchor at each edge (#580).
+    # Floor only the internal gapfill anchor window so interpolate() has an anchor
+    # at each edge, then clip the output back to the requested start so the forecast
+    # series doesn't extend earlier than the window the caller asked for (#580 review).
+    output_start = date_start
     date_start = _floor_to_30min(date_start)
     date_end = _floor_to_30min(date_end)
 
     return text(f"""
-        select
-            time_bucket_gapfill('{bucket}', fs.interval) as interval,
-            u.fueltech_id,
-            interpolate(coalesce(sum(fs.generated), 0)) as generated,
-            interpolate(coalesce(sum(fs.energy), 0)) as energy
-        from facility_scada fs
-        join units u on fs.facility_code = u.code
-        join facilities f on f.id = u.station_id
-        where
-            (fs.network_id in ('AEMO_ROOFTOP', 'AEMO_ROOFTOP_BACKFILL')
-             or (fs.network_id = 'APVI' and f.network_region = 'WEM'))
-            and fs.interval between '{date_start}' and '{date_end}'
-            and fs.is_forecast = true
-            {network_query} {region_q}
-        group by 1, 2
+        select * from (
+            select
+                time_bucket_gapfill('{bucket}', fs.interval) as interval,
+                u.fueltech_id,
+                interpolate(coalesce(sum(fs.generated), 0)) as generated,
+                interpolate(coalesce(sum(fs.energy), 0)) as energy
+            from facility_scada fs
+            join units u on fs.facility_code = u.code
+            join facilities f on f.id = u.station_id
+            where
+                (fs.network_id in ('AEMO_ROOFTOP', 'AEMO_ROOFTOP_BACKFILL')
+                 or (fs.network_id = 'APVI' and f.network_region = 'WEM'))
+                and fs.interval between '{date_start}' and '{date_end}'
+                and fs.is_forecast = true
+                {network_query} {region_q}
+            group by 1, 2
+        ) gapfilled
+        where interval >= '{output_start}'
         order by 1 desc, 2;
     """)
 
@@ -154,7 +161,11 @@ def get_rooftop_generation_combined_query(
     # Snap the start down to the 30-min grid too. Rooftop actuals are 30-min;
     # gapfilling to 5-min with interpolate() can't extrapolate before the first
     # anchor, so an off-grid start (eg range.start at :50) leaves the leading
-    # 5-min buckets null at the oldest edge of every export (#580).
+    # 5-min buckets null at the oldest edge of every export (#580). We floor only
+    # the internal anchor window and clip the output back to the requested start
+    # (output_start) so the rooftop series doesn't extend earlier than the core
+    # generation series (#580 review).
+    output_start = date_start
     date_start = _floor_to_30min(date_start)
 
     networks = [i.code for i in network.subnetworks] if network.subnetworks else [network.code]
@@ -189,14 +200,17 @@ def get_rooftop_generation_combined_query(
                  ELSE null END as is_forecast
         FROM rooftop_data GROUP BY 1, 2, 3
     )
-    SELECT time_bucket_gapfill('{bucket}', interval) as interval,
-        'solar_rooftop' as fueltech_id,
-        interpolate(sum(generated)) as generated,
-        interpolate(sum(energy)) as energy,
-        bool_or(is_forecast) as is_forecast
-    FROM combined_data
-    WHERE interval between '{date_start}' and '{date_end}'
-        and {network_query} {region_q}
-    GROUP BY 1, 2
+    SELECT * FROM (
+        SELECT time_bucket_gapfill('{bucket}', interval) as interval,
+            'solar_rooftop' as fueltech_id,
+            interpolate(sum(generated)) as generated,
+            interpolate(sum(energy)) as energy,
+            bool_or(is_forecast) as is_forecast
+        FROM combined_data
+        WHERE interval between '{date_start}' and '{date_end}'
+            and {network_query} {region_q}
+        GROUP BY 1, 2
+    ) gapfilled
+    WHERE interval >= '{output_start}'
     ORDER BY interval DESC;
     """)

--- a/opennem/queries/power.py
+++ b/opennem/queries/power.py
@@ -91,6 +91,11 @@ def get_fueltech_power_query_clickhouse(
 # --- Rooftop queries — stay on PostgreSQL facility_scada ---
 
 
+def _floor_to_30min(dt: datetime) -> datetime:
+    """Floor a datetime down to the previous 30-minute boundary."""
+    return dt.replace(minute=dt.minute - dt.minute % 30, second=0, microsecond=0)
+
+
 def get_rooftop_forecast_generation_query(
     network: NetworkSchema,
     date_start: datetime,
@@ -105,6 +110,14 @@ def get_rooftop_forecast_generation_query(
     network_query = f"and fs.network_id in ({list_to_case(networks)})"
     region_q = f"and f.network_region = '{network_region}'" if network_region else ""
     bucket = "30min" if network == NetworkAU else "5min"
+
+    # AEMO rooftop forecast is on a 30-min grid. When gapfilling to a 5-min grid,
+    # interpolate() cannot extrapolate before the first anchor or after the last,
+    # so a window bound that lands off the 30-min grid (eg range.end at :45) leaves
+    # the leading/trailing 5-min buckets null. Snap both bounds down to the 30-min
+    # grid so gapfill always has an anchor at each edge (#580).
+    date_start = _floor_to_30min(date_start)
+    date_end = _floor_to_30min(date_end)
 
     return text(f"""
         select

--- a/opennem/queries/power.py
+++ b/opennem/queries/power.py
@@ -151,6 +151,12 @@ def get_rooftop_generation_combined_query(
     if minutes % 30 != 0:
         date_end = date_end - timedelta(minutes=minutes % 30)
 
+    # Snap the start down to the 30-min grid too. Rooftop actuals are 30-min;
+    # gapfilling to 5-min with interpolate() can't extrapolate before the first
+    # anchor, so an off-grid start (eg range.start at :50) leaves the leading
+    # 5-min buckets null at the oldest edge of every export (#580).
+    date_start = _floor_to_30min(date_start)
+
     networks = [i.code for i in network.subnetworks] if network.subnetworks else [network.code]
     if network == NetworkAU:
         networks.extend(["AEMO_ROOFTOP", "AEMO_ROOFTOP_BACKFILL", "APVI"])

--- a/tests/test_rooftop.py
+++ b/tests/test_rooftop.py
@@ -3,7 +3,11 @@ from datetime import datetime
 import pytest
 
 from opennem.importer.rooftop import rooftop_remap_regionids
-from opennem.queries.power import _floor_to_30min, get_rooftop_forecast_generation_query
+from opennem.queries.power import (
+    _floor_to_30min,
+    get_rooftop_forecast_generation_query,
+    get_rooftop_generation_combined_query,
+)
 from opennem.schema.network import NetworkNEM
 
 
@@ -67,3 +71,19 @@ def test_rooftop_forecast_query_snaps_window_to_30min() -> None:
     assert "2026-06-25 08:30:00" in query
     assert "2026-06-26 08:30:00" in query
     assert "08:45:00" not in query
+
+
+def test_rooftop_combined_query_snaps_start_to_30min() -> None:
+    """Combined generation window start must snap to the 30-min grid so the
+    5-min gapfill/interpolate has a leading anchor — otherwise an off-grid
+    range.start leaves the oldest 5-min buckets null (#580)."""
+    query = str(
+        get_rooftop_generation_combined_query(
+            network=NetworkNEM,
+            date_start=datetime(2026, 6, 18, 9, 50, 0),
+            date_end=datetime(2026, 6, 25, 9, 50, 0),
+        )
+    )
+    # start snapped down 09:50 -> 09:30, end also floored 09:50 -> 09:30
+    assert "2026-06-18 09:30:00" in query
+    assert "09:50:00" not in query

--- a/tests/test_rooftop.py
+++ b/tests/test_rooftop.py
@@ -68,9 +68,12 @@ def test_rooftop_forecast_query_snaps_window_to_30min() -> None:
             date_end=datetime(2026, 6, 26, 8, 45, 0),
         )
     )
+    # internal gapfill anchor window floored to the 30-min grid
     assert "2026-06-25 08:30:00" in query
     assert "2026-06-26 08:30:00" in query
-    assert "08:45:00" not in query
+    # output clipped back to the requested start so the series doesn't extend
+    # earlier than the requested window (#580 review)
+    assert "interval >= '2026-06-25 08:45:00'" in query
 
 
 def test_rooftop_combined_query_snaps_start_to_30min() -> None:
@@ -84,6 +87,8 @@ def test_rooftop_combined_query_snaps_start_to_30min() -> None:
             date_end=datetime(2026, 6, 25, 9, 50, 0),
         )
     )
-    # start snapped down 09:50 -> 09:30, end also floored 09:50 -> 09:30
+    # start snapped down 09:50 -> 09:30 for the internal gapfill anchor window
     assert "2026-06-18 09:30:00" in query
-    assert "09:50:00" not in query
+    # output clipped back to the requested start so rooftop doesn't extend
+    # earlier than the core generation series (#580 review)
+    assert "interval >= '2026-06-18 09:50:00'" in query

--- a/tests/test_rooftop.py
+++ b/tests/test_rooftop.py
@@ -1,6 +1,10 @@
+from datetime import datetime
+
 import pytest
 
 from opennem.importer.rooftop import rooftop_remap_regionids
+from opennem.queries.power import _floor_to_30min, get_rooftop_forecast_generation_query
+from opennem.schema.network import NetworkNEM
 
 
 @pytest.mark.parametrize(
@@ -33,3 +37,33 @@ def test_remap_region_code(region_code: str, region_code_expected: str) -> None:
 def test_rooftop_remap_regionids(rooftop_record: dict, rooftop_record_expected: dict) -> None:
     rooftop_record_remapped = rooftop_remap_regionids(rooftop_record)
     assert rooftop_record_remapped == rooftop_record_expected
+
+
+@pytest.mark.parametrize(
+    "dt,expected",
+    [
+        (datetime(2026, 6, 25, 8, 45, 0), datetime(2026, 6, 25, 8, 30, 0)),
+        (datetime(2026, 6, 25, 8, 30, 0), datetime(2026, 6, 25, 8, 30, 0)),
+        (datetime(2026, 6, 25, 8, 0, 0), datetime(2026, 6, 25, 8, 0, 0)),
+        (datetime(2026, 6, 25, 8, 29, 59, 500000), datetime(2026, 6, 25, 8, 0, 0)),
+        (datetime(2026, 6, 25, 8, 59, 0), datetime(2026, 6, 25, 8, 30, 0)),
+    ],
+)
+def test_floor_to_30min(dt: datetime, expected: datetime) -> None:
+    assert _floor_to_30min(dt) == expected
+
+
+def test_rooftop_forecast_query_snaps_window_to_30min() -> None:
+    """Forecast window bounds must snap to the 30-min AEMO rooftop grid so the
+    5-min gapfill/interpolate has an anchor at each edge (no leading/trailing
+    nulls — #580)."""
+    query = str(
+        get_rooftop_forecast_generation_query(
+            network=NetworkNEM,
+            date_start=datetime(2026, 6, 25, 8, 45, 0),
+            date_end=datetime(2026, 6, 26, 8, 45, 0),
+        )
+    )
+    assert "2026-06-25 08:30:00" in query
+    assert "2026-06-26 08:30:00" in query
+    assert "08:45:00" not in query


### PR DESCRIPTION
closes #580

## what

the solar_rooftop series in the static power exports (eg `/v4/stats/au/NEM/power/7d.json`) has nulls in both the `forecast` block and the generation `history`. the maintainer comment reports the generation nulls recurring at the same times each day.

## root cause

both come from the same edge-alignment bug. the rooftop queries in `opennem/queries/power.py` gapfill the 30-min AEMO rooftop data to a 5-min grid via `time_bucket_gapfill('5min', fs.interval)` + `interpolate()`. `interpolate()` cannot extrapolate before the first anchor or after the last. when a window bound lands off the 30-min grid (:00/:30), the anchor just outside the window is excluded and the edge 5-min buckets are served as null.

- **forecast** (`get_rooftop_forecast_generation_query`): caller passes `date_start = range.end` (eg 08:45) and `date_end = end + 1 day`, both off-grid -> 3 leading + 3 trailing nulls.
- **generation** (`get_rooftop_generation_combined_query`): already floored `date_end` but not `date_start`. caller passes `date_start = range.start` (eg 09:50, off-grid) -> the leading 5-min buckets at the oldest edge are null. live prod `7d.json` showed exactly 2 leading nulls at start 09:50; these get baked into the frontend's rolling store, which is what shows as recurring rooftop-line gaps.

confirmed on dev + against live prod json: forecast 6 nulls -> 0, generation 2 leading nulls -> 0. on-grid starts already had 0 nulls, proving the source data itself is complete (not a crawl/backfill gap).

## fix

floor the query window bounds down to the 30-min source grid (`_floor_to_30min`) so gapfill always has an anchor at each edge:
- forecast: floor both `date_start` and `date_end`
- generation: floor `date_start` too (mirroring the existing `date_end` floor)

scoped to the two rooftop queries. does not touch the separate trailing-edge fill-forward in #579 (rooftop generation history ending ~15min before core gen), which is a different symptom.

## test

`tests/test_rooftop.py`: unit tests for `_floor_to_30min` + asserts both generated queries snap their window bounds to the 30-min grid.
