### PR TITLE
fix(worker): run interval-check clickhouse writes off the event loop (#572)

### DIFF
--- a/opennem/aggregates/market_summary.py
+++ b/opennem/aggregates/market_summary.py
@@ -14,7 +14,7 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from opennem.db import get_write_session
-from opennem.db.clickhouse import get_clickhouse_client
+from opennem.db.clickhouse import execute_async, get_clickhouse_client, insert_async
 from opennem.db.clickhouse.materialized_views import backfill_materialized_views
 from opennem.db.clickhouse.schema import optimize_clickhouse_tables
 from opennem.db.clickhouse.views import (
@@ -762,7 +762,7 @@ async def _compute_flows_for_range(start_time: datetime, end_time: datetime) -> 
         )
         ORDER BY 1
     """
-    em_rows = client.execute(em_query)
+    em_rows = await execute_async(client, em_query)
 
     if not em_rows:
         logger.debug(f"No emissions data for {start_str} to {end_str}")
@@ -961,9 +961,7 @@ async def run_market_summary_aggregate_for_last_intervals(num_intervals: int) ->
 
     prepared_data = await _prepare_market_summary_data(records)
 
-    client = get_clickhouse_client()
-
-    client.execute(
+    await insert_async(
         """
         INSERT INTO market_summary
         (

--- a/opennem/aggregates/unit_intervals.py
+++ b/opennem/aggregates/unit_intervals.py
@@ -5,6 +5,7 @@ This module handles the aggregation of unit interval data from PostgreSQL to Cli
 It calculates energy values, emissions, and market values for each unit and stores them in ClickHouse.
 """
 
+import asyncio
 import gc
 import logging
 import resource
@@ -19,7 +20,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from opennem.db import get_write_session
 from opennem.db.clickhouse import (
     create_table_if_not_exists,
+    execute_async,
     get_clickhouse_client,
+    insert_async,
     table_exists,
 )
 from opennem.db.clickhouse.materialized_views import (
@@ -609,8 +612,9 @@ async def process_unit_intervals_backlog(
         chunk_size: Size of each processing chunk
     """
     current_start = start_date
-    client = get_clickhouse_client()
-    _ensure_clickhouse_schema()
+    # Schema-ensure and inserts hit the blocking sync CH driver. This runs while `session`
+    # holds a checked-out asyncpg connection, so keep them off the event loop (#572).
+    await asyncio.to_thread(_ensure_clickhouse_schema)
 
     logger.info(f"Processing unit intervals from {current_start} to {end_date} for network {network.code if network else 'all'}")
 
@@ -623,8 +627,8 @@ async def process_unit_intervals_backlog(
         if records:
             prepared_data = _prepare_unit_interval_data(records)
 
-            # Batch insert into ClickHouse
-            client.execute(
+            # Batch insert into ClickHouse (off-loop — see note above)
+            await insert_async(
                 """
                 INSERT INTO unit_intervals
                 (
@@ -744,13 +748,17 @@ async def run_unit_intervals_aggregate_to_now() -> int:
     client = get_clickhouse_client()
 
     # Use NEM's max interval as the baseline — WEM lags ~24h and would block
-    # the incremental path if we used MIN across all networks
-    result = client.execute("""
+    # the incremental path if we used MIN across all networks.
+    # Off-loop: this runs concurrently (asyncio.gather) with the power exports (#572).
+    result = await execute_async(
+        client,
+        """
         SELECT MAX(interval)
         FROM unit_intervals FINAL
         WHERE interval > now() - INTERVAL 2 DAY
             AND network_id = 'NEM'
-    """)
+    """,
+    )
     min_max_interval = result[0][0]
 
     date_from = min_max_interval + timedelta(minutes=5)
@@ -769,7 +777,7 @@ async def run_unit_intervals_aggregate_to_now() -> int:
         records = await _get_unit_interval_data(session, date_from, date_to)
         prepared_data = _prepare_unit_interval_data(records)
 
-    client.execute(
+    await insert_async(
         """
         INSERT INTO unit_intervals
         (

--- a/opennem/db/clickhouse/__init__.py
+++ b/opennem/db/clickhouse/__init__.py
@@ -11,6 +11,7 @@ from opennem.db.clickhouse.client import (
     get_clickhouse_client,
     get_clickhouse_context,
     get_clickhouse_dependency,
+    insert_async,
     table_exists,
 )
 
@@ -21,5 +22,6 @@ __all__ = [
     "get_clickhouse_client",
     "get_clickhouse_context",
     "get_clickhouse_dependency",
+    "insert_async",
     "table_exists",
 ]

--- a/opennem/db/clickhouse/client.py
+++ b/opennem/db/clickhouse/client.py
@@ -87,6 +87,26 @@ async def execute_async(client: Client, query: str, params: dict | None = None, 
     return await asyncio.to_thread(_run)
 
 
+async def insert_async(query: str, data: Any = None, timeout: int = 10) -> Any:
+    """Run a blocking clickhouse-driver write (INSERT / DDL) in a thread so the
+    asyncio event loop keeps servicing async connections.
+
+    This is the aggregation/write-path counterpart to ``execute_async``. It does NOT
+    apply the serving-path resource limits (see ``_serving_query_settings``) — those cap
+    read queries that share the server with API traffic, and would wrongly bound bulk
+    inserts. Uses a thread-local Client so concurrent writes are thread-safe.
+
+    Blocking these calls on the event loop starves asyncpg connections that are checked
+    out from the pool, which drops them mid-transaction and leaks the session (issue #572).
+    """
+
+    def _run() -> Any:
+        tl_client = get_clickhouse_client(timeout)
+        return tl_client.execute(query, data)
+
+    return await asyncio.to_thread(_run)
+
+
 @asynccontextmanager
 async def get_clickhouse_context() -> AsyncGenerator[Client, None]:
     """

--- a/tests/db/test_clickhouse_client.py
+++ b/tests/db/test_clickhouse_client.py
@@ -1,5 +1,9 @@
 """Tests for the ClickHouse serving-path query settings applied by execute_async."""
 
+import asyncio
+import threading
+import time
+
 import pytest
 
 from opennem import settings
@@ -56,3 +60,50 @@ async def test_limits_can_be_disabled(fake_client: _FakeClient, monkeypatch: pyt
     await ch_client.execute_async(fake_client, "SELECT 1")
 
     assert fake_client.calls[-1]["kwargs"]["settings"] == {}
+
+
+@pytest.mark.asyncio
+async def test_insert_async_passes_data_without_serving_settings(fake_client: _FakeClient) -> None:
+    """Write path must forward the row data and NOT apply serving-path resource limits."""
+    rows = [(1, "a"), (2, "b")]
+
+    await ch_client.insert_async("INSERT INTO t VALUES", rows)
+
+    call = fake_client.calls[-1]
+    assert call["params"] == rows
+    # no settings kwarg (serving limits) on the write path
+    assert "settings" not in call["kwargs"]
+
+
+@pytest.mark.asyncio
+async def test_insert_async_runs_off_event_loop(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The blocking driver call must run in a worker thread so the loop stays responsive.
+
+    Regression guard for #572: blocking the event loop starves asyncpg connections that
+    are checked out from the pool and leaks them.
+    """
+    loop_thread = threading.get_ident()
+    exec_thread: list[int] = []
+
+    class _BlockingClient:
+        def execute(self, query, data=None, **kwargs):  # noqa: ANN001, ANN003
+            exec_thread.append(threading.get_ident())
+            time.sleep(0.2)
+            return []
+
+    monkeypatch.setattr(ch_client, "get_clickhouse_client", lambda *a, **k: _BlockingClient())
+
+    ticks = 0
+
+    async def _ticker() -> None:
+        nonlocal ticks
+        for _ in range(10):
+            await asyncio.sleep(0.02)
+            ticks += 1
+
+    await asyncio.gather(ch_client.insert_async("INSERT INTO t VALUES", [(1,)]), _ticker())
+
+    # the concurrent coroutine kept running during the 0.2s blocking insert
+    assert ticks == 10
+    # and the blocking call did not run on the event loop thread
+    assert exec_thread and exec_thread[0] != loop_thread


### PR DESCRIPTION
closes #572

## root cause
the interval-check tasks run the synchronous clickhouse-driver `client.execute()` directly on the asyncio event loop. clickhouse-driver is fully blocking socket i/o, so while it runs (seconds, esp. for inserts) asyncpg can't service its sockets. that produces the whole sentry cluster:

- `connection_lost()` (5AY), `client_login_timeout` (5AR), `TimeoutError` (5AW), `CancelledError` (5AX)
- and the key signal: SQLAlchemy "garbage collector is trying to clean up non-checked-in connection ... will be terminated" (5B3, 29x) — a real pool leak

the most acute leak: `process_unit_intervals_backlog` (reached from `task_wem_interval_check` every 5 min and `task_wem_day_crawl` hourly) runs the blocking CH insert *inside* an open `async with get_write_session()`. the pg connection is checked out while the loop is starved, so it dies mid-flight and the abandoned session gets GC-reclaimed.

this is exactly what CLAUDE.md warns about ("wrap any remaining sync CH/PG calls in `asyncio.to_thread()`"). the repo already has `execute_async` (off-loop, thread-local client) for the serving/read path — the aggregation write path just bypassed it.

## fix
- add `insert_async` in `opennem/db/clickhouse/client.py`: write-path counterpart to `execute_async`. runs the blocking `Client.execute(query, data)` in a worker thread via `asyncio.to_thread`, using a thread-local client (thread-safe, mirrors execute_async). no serving-path resource limits — those are read-query caps that would wrongly bound bulk inserts (per the settings_schema comment "backfills use the sync client directly and are unaffected").
- route the incremental interval-check CH calls off the loop:
  - `process_unit_intervals_backlog`: schema-ensure → `to_thread`, insert → `insert_async` (the in-session leak fix)
  - `run_unit_intervals_aggregate_to_now`: SELECT MAX → `execute_async`, insert → `insert_async` (runs concurrently with the power exports via `asyncio.gather`)
  - `run_market_summary_aggregate_for_last_intervals`: insert → `insert_async`
  - `_compute_flows_for_range`: emissions SELECT → `execute_async`

## scope
- backfill/reset/streaming paths keep the sync client (documented design, not in the cluster)
- no pool_size / timeout / pgbouncer changes — the leak is loop-blocking, not pool exhaustion

## verification
- new tests in `tests/db/test_clickhouse_client.py`: `insert_async` forwards row data with no serving `settings` kwarg; and it runs the blocking call on a non-loop thread while a concurrent ticker coroutine keeps ticking through a 0.2s blocking insert
- `uv run pytest tests/db tests/aggregates` → 12 passed; ruff format + check clean
- codex review: 5/5 ship, verified no in-session blocking CH call remains in the interval-check call graph