### PR TITLE
fix(recordreactor): exclude battery storage from wa fossils record #585

### DIFF
--- a/opennem/db/clickhouse/views.py
+++ b/opennem/db/clickhouse/views.py
@@ -218,6 +218,13 @@ FUELTECH_INTERVALS_DAILY_VIEW = MaterializedView(
 # Renewable MVs clamp negative generated/energy to 0: negative scada values are unit
 # auxiliary loads (unit powered while not generating), not negative generation, and must
 # not subtract from renewable totals (records/milestones + renewable proportion).
+#
+# Storage/load fueltechs (pumps + battery charging/discharging/bidirectional) are excluded
+# entirely: these MVs split generation into renewable (=1) vs fossils (=0) for the
+# renewables/fossils milestone records, and storage is neither. Batteries are renewable=0,
+# so without this exclusion their (clamp-inflated) charge+discharge energy lands in the
+# "fossils" bucket — as WA's battery fleet grew in 2025-2026 this inflated the WA fossil
+# records ~30% above true coal+gas+distillate generation (GH #585).
 RENEWABLE_INTERVALS_VIEW = MaterializedView(
     name="renewable_intervals_mv",
     timestamp_column="interval",
@@ -238,7 +245,7 @@ RENEWABLE_INTERVALS_VIEW = MaterializedView(
             count() as unit_count,
             max(version) as version
         FROM unit_intervals
-        WHERE fueltech_id not in ('pumps')
+        WHERE fueltech_id not in ('pumps', 'battery', 'battery_charging', 'battery_discharging')
         GROUP BY interval, network_id, network_region, renewable
     """,
     backfill_query="""
@@ -256,7 +263,8 @@ RENEWABLE_INTERVALS_VIEW = MaterializedView(
             count() as unit_count,
             max(version) as version
         FROM unit_intervals FINAL
-        WHERE fueltech_id not in ('pumps') and interval >= %(start)s AND interval <= %(end)s
+        WHERE fueltech_id not in ('pumps', 'battery', 'battery_charging', 'battery_discharging')
+          and interval >= %(start)s AND interval <= %(end)s
         GROUP BY interval, network_id, network_region, renewable
     """,
 )
@@ -284,7 +292,7 @@ RENEWABLE_INTERVALS_DAILY_VIEW = MaterializedView(
             count(distinct interval) as interval_count,
             toUInt64(count(distinct interval)) * 1000000000 + max(version) as version
         FROM unit_intervals
-        WHERE fueltech_id not in ('pumps')
+        WHERE fueltech_id not in ('pumps', 'battery', 'battery_charging', 'battery_discharging')
         GROUP BY date, network_id, network_region, renewable
     """,
     backfill_query="""
@@ -304,7 +312,8 @@ RENEWABLE_INTERVALS_DAILY_VIEW = MaterializedView(
             count(distinct interval) as interval_count,
             toUInt64(count(distinct interval)) * 1000000000 + max(version) as version
         FROM unit_intervals FINAL
-        WHERE fueltech_id not in ('pumps') and interval >= %(start)s AND interval <= %(end)s
+        WHERE fueltech_id not in ('pumps', 'battery', 'battery_charging', 'battery_discharging')
+          and interval >= %(start)s AND interval <= %(end)s
         GROUP BY date, network_id, network_region, renewable
     """,
 )

--- a/tests/db/test_clickhouse_views.py
+++ b/tests/db/test_clickhouse_views.py
@@ -1,0 +1,19 @@
+"""Tests for ClickHouse materialized view definitions."""
+
+from opennem.db.clickhouse.views import (
+    RENEWABLE_INTERVALS_DAILY_VIEW,
+    RENEWABLE_INTERVALS_VIEW,
+)
+
+# Storage/load fueltechs must be excluded from the renewable MVs: they split generation into
+# renewable (=1) vs fossils (=0) for the milestone records, and storage is neither. Batteries
+# are renewable=0, so without this exclusion their charge+discharge energy pollutes the
+# "fossils" bucket and inflates fossil records (GH #585).
+_STORAGE_FUELTECHS = ("battery", "battery_charging", "battery_discharging", "pumps")
+
+
+def test_renewable_mvs_exclude_storage_fueltechs() -> None:
+    for view in (RENEWABLE_INTERVALS_VIEW, RENEWABLE_INTERVALS_DAILY_VIEW):
+        for sql in (view.schema, view.backfill_query):
+            for fueltech in _STORAGE_FUELTECHS:
+                assert f"'{fueltech}'" in sql, f"{view.name} must exclude '{fueltech}' storage fueltech"


### PR DESCRIPTION
closes #585

## problem
wa (wem) highest monthly fossils record didn't match the tracker for jun 2026. earlier months matched.

## root cause
the fossils/renewables milestone records read `renewable_intervals_mv` / `renewable_intervals_daily_mv`, which group `unit_intervals` by the per-unit `renewable` flag with `sum(greatest(energy,0))` and only excluded `pumps`. battery fueltechs (`battery`, `battery_charging`, `battery_discharging`) are `renewable=0`, so all their energy landed in the `renewable=0` -> "fossils" bucket. the `greatest(energy,0)` clamp made it worse: the bidirectional `battery` fueltech is a net consumer (jun 2026 net -17,434 mwh) but per-interval clamping turned it into +122,868 mwh of phantom "fossil" energy.

storage was negligible in wa until ~2025, which is why earlier records matched. wa battery clamped energy grew from ~14k mwh/month (early 2024) to ~387k mwh/month (jun 2026) as the fleet came online:

| jun 2026 wem | mwh |
|---|---|
| record (renewable=0, old) | 1,758,795 |
| battery in that bucket (charge+discharge+bidir) | 387,233 |
| corrected fossils (coal+gas+distillate, excl storage) | 1,388,809 |

the record was ~27% too high. with the fix, jun 2026 is no longer the all-time high; the true wa monthly fossils record reverts to jun 2023 (1,424,538 mwh).

## fix
exclude the three battery storage fueltechs from both renewable mv schema + backfill where clauses, same treatment pumps already gets. storage is neither renewable nor fossil generation. adds a regression test.

blast radius: only `recordreactor/metric_registry.py` + `backlog.py` consume these mvs (fossils/renewables energy/power/emissions records). renewable proportion uses `market_summary`, unaffected. the `renewable=1` side is unaffected since batteries are `renewable=0`. per-fueltech records read the untouched `fueltech_intervals_mv`.

## follow-up (prod data ops, NOT in this pr)
the code change only affects future mv auto-population. to correct historical records on prod: backfill `renewable_intervals_mv` + `renewable_intervals_daily_mv` (delete-before-insert), then re-run the milestone backlog for fossils/renewables so existing inflated records are recomputed.