### PR TITLE
fix(crawler): age-out rolled-off rooftop intervals + quiet expected nemweb fetch logs

### DIFF
--- a/opennem/core/parsers/aemo/nemweb.py
+++ b/opennem/core/parsers/aemo/nemweb.py
@@ -3,12 +3,22 @@
 import logging
 from shutil import rmtree
 
+from rnet.exceptions import TimeoutError as RnetTimeoutError
+
 from opennem.controllers.nem import store_aemo_tableset
 from opennem.controllers.schema import ControllerReturn
 from opennem.core.parsers.aemo.mms import AEMOTableSet, parse_aemo_file
 from opennem.utils.archive import download_and_unzip
 
 logger = logging.getLogger("opennem.core.parsers.aemo.nemweb")
+
+
+def _log_download_error(url: str, error: Exception) -> None:
+    """Nemweb download timeouts are transient and expected on large files - don't page on them"""
+    if isinstance(error, RnetTimeoutError):
+        logger.warning(f"Timed out downloading and unzipping {url}: {error}")
+    else:
+        logger.error(f"Error downloading and unzipping {url}: {error}")
 
 
 async def parse_aemo_url_optimized(
@@ -21,7 +31,7 @@ async def parse_aemo_url_optimized(
     try:
         download_path = await download_and_unzip(url)
     except Exception as e:
-        logger.error(f"Error downloading and unzipping {url}: {e}")
+        _log_download_error(url, e)
         return cr
 
     download_path_files = [f for f in download_path.iterdir() if f.is_file()]
@@ -73,7 +83,7 @@ async def parse_aemo_url_optimized_bulk(
     try:
         download_path = await download_and_unzip(url)
     except Exception as e:
-        logger.error(f"Error downloading and unzipping {url}: {e}")
+        _log_download_error(url, e)
         return cr
 
     download_path_files = [f for f in download_path.iterdir() if f.is_file()]

--- a/opennem/crawlers/nemweb.py
+++ b/opennem/crawlers/nemweb.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from opennem.controllers.nem import ControllerReturn, store_aemo_tableset
 from opennem.core.crawlers.history import CrawlHistoryEntry, get_crawler_missing_intervals, set_crawler_history
@@ -16,6 +16,33 @@ from opennem.schema.date_range import CrawlDateRange
 from opennem.schema.network import NetworkAEMORooftop, NetworkNEM
 
 logger = logging.getLogger("opennem.crawler.nemweb")
+
+# once a listed file 404s and its interval is older than this, it has rolled off CURRENT
+# for good and will 404 forever - stop treating it as a live-crawler error and let the
+# ARCHIVE/catchup crawler (separate crawler_name) own backfilling it
+ENTRY_ROLLOFF_AGE = timedelta(days=3)
+
+
+async def _handle_fetch_error(crawler: CrawlerDefinition, entry: DirlistingEntry, error: Exception) -> None:
+    """Logs a failed fetch of a listed entry, aging out rolled-off files so they stop retrying forever"""
+    if "404" not in str(error):
+        logger.error(f"Error parsing {entry.link}: {error}")
+        return
+
+    logger.warning(f"Fetch 404 for {entry.link}: {error}")
+
+    entry_date = entry.aemo_interval_date.date if entry.aemo_interval_date else None
+
+    if not entry_date or datetime.now() - entry_date <= ENTRY_ROLLOFF_AGE:
+        # still within the live window - this crawler's next run may find it back, keep retrying
+        return
+
+    # the file is long gone from CURRENT - record a zero-result history entry under this
+    # crawler's name so get_crawler_missing_intervals stops re-queuing it here every run
+    try:
+        await set_crawler_history(crawler_name=crawler.name, histories=[CrawlHistoryEntry(interval=entry_date, records=0)])
+    except Exception as e:
+        logger.error(f"Error recording age-out history for {entry.link}: {e}")
 
 
 async def process_nemweb_entry(crawler: CrawlerDefinition, entry: DirlistingEntry, max_date: datetime) -> ControllerReturn:
@@ -33,7 +60,7 @@ async def process_nemweb_entry(crawler: CrawlerDefinition, entry: DirlistingEntr
                 ts = await parse_aemo_url(entry.link)
                 controller_return = await store_aemo_tableset(ts)
             except Exception as e:
-                logger.error(f"Error parsing {entry.link}: {e}")
+                await _handle_fetch_error(crawler=crawler, entry=entry, error=e)
                 return None
     except Exception as e:
         logger.error(f"Processing error: {e}")
@@ -43,7 +70,7 @@ async def process_nemweb_entry(crawler: CrawlerDefinition, entry: DirlistingEntr
 
     # don't update crawl time if it fails
     if not controller_return.inserted_records:
-        logger.error(f"No records inserted for {entry.link}")
+        logger.warning(f"No records inserted for {entry.link}")
         return controller_return
 
     if not controller_return.last_modified or max_date > controller_return.last_modified:

--- a/tests/crawlers/test_nemweb_fetch_error_handling.py
+++ b/tests/crawlers/test_nemweb_fetch_error_handling.py
@@ -1,0 +1,103 @@
+"""Fetch-404s for files that have rolled off the nemweb CURRENT directory should age out
+(stop being logged/retried as errors here) rather than paging sentry forever - the
+ARCHIVE/catchup crawler owns backfilling them. See GH #571."""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from opennem.core.crawlers.schema import CrawlerDefinition, CrawlerPriority
+from opennem.core.parsers.aemo.filenames import AEMOMMSFilename
+from opennem.core.parsers.dirlisting import DirlistingEntry
+from opennem.crawlers.nemweb import ENTRY_ROLLOFF_AGE, _handle_fetch_error, run_nemweb_aemo_crawl
+
+
+def _entry(interval_date: datetime | None) -> DirlistingEntry:
+    return DirlistingEntry(
+        filename="PUBLIC_ROOFTOP_PV_ACTUAL_MEASUREMENT_20260603103000.zip",
+        link="https://nemweb.com.au/PUBLIC_ROOFTOP_PV_ACTUAL_MEASUREMENT_20260603103000.zip",
+        modified_date=datetime(2026, 6, 3, 10, 30, 0),
+        aemo_interval_date=AEMOMMSFilename(filename="ROOFTOP", date=interval_date) if interval_date else None,
+    )
+
+
+def _crawler() -> CrawlerDefinition:
+    return CrawlerDefinition(name="au.nemweb.current.rooftop", priority=CrawlerPriority.high, processor=run_nemweb_aemo_crawl)
+
+
+@pytest.mark.asyncio
+async def test_recent_404_is_not_aged_out(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A 404 on a file still inside the rolloff window should just log and retry next run"""
+    called = False
+
+    async def _fake_set_crawler_history(*args, **kwargs):  # noqa: ANN002, ANN003, ANN201
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr("opennem.crawlers.nemweb.set_crawler_history", _fake_set_crawler_history)
+
+    recent_entry = _entry(datetime.now() - timedelta(hours=1))
+    await _handle_fetch_error(crawler=_crawler(), entry=recent_entry, error=Exception("HTTP Error 404: not found"))
+
+    assert not called
+
+
+@pytest.mark.asyncio
+async def test_stale_404_ages_out_via_crawler_history(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A 404 on a file well past the rolloff window has fallen off CURRENT for good -
+    record a zero-result history entry so this crawler stops re-queuing it"""
+    recorded: list = []
+
+    async def _fake_set_crawler_history(crawler_name, histories):  # noqa: ANN001, ANN201
+        recorded.append((crawler_name, histories))
+
+    monkeypatch.setattr("opennem.crawlers.nemweb.set_crawler_history", _fake_set_crawler_history)
+
+    stale_date = datetime.now() - ENTRY_ROLLOFF_AGE - timedelta(days=1)
+    stale_entry = _entry(stale_date)
+    crawler = _crawler()
+
+    await _handle_fetch_error(crawler=crawler, entry=stale_entry, error=Exception("HTTP Error 404: not found"))
+
+    assert len(recorded) == 1
+    crawler_name, histories = recorded[0]
+    assert crawler_name == crawler.name
+    assert histories[0].interval == stale_date
+    assert histories[0].records == 0
+
+
+@pytest.mark.asyncio
+async def test_non_404_error_never_ages_out(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-404 fetch errors are real problems - never silently age them out"""
+    called = False
+
+    async def _fake_set_crawler_history(*args, **kwargs):  # noqa: ANN002, ANN003, ANN201
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr("opennem.crawlers.nemweb.set_crawler_history", _fake_set_crawler_history)
+
+    stale_date = datetime.now() - ENTRY_ROLLOFF_AGE - timedelta(days=1)
+    stale_entry = _entry(stale_date)
+
+    await _handle_fetch_error(crawler=_crawler(), entry=stale_entry, error=Exception("Connection reset by peer"))
+
+    assert not called
+
+
+@pytest.mark.asyncio
+async def test_missing_interval_date_never_ages_out(monkeypatch: pytest.MonkeyPatch) -> None:
+    """If the filename couldn't be parsed into a date there's no age to check against"""
+    called = False
+
+    async def _fake_set_crawler_history(*args, **kwargs):  # noqa: ANN002, ANN003, ANN201
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr("opennem.crawlers.nemweb.set_crawler_history", _fake_set_crawler_history)
+
+    entry_no_date = _entry(None)
+
+    await _handle_fetch_error(crawler=_crawler(), entry=entry_no_date, error=Exception("HTTP Error 404: not found"))
+
+    assert not called

--- a/tests/parsers/test_aemo_nemweb_download_errors.py
+++ b/tests/parsers/test_aemo_nemweb_download_errors.py
@@ -1,0 +1,28 @@
+"""Nemweb download timeouts on large files (eg. Next_Day_Dispatch) are transient and
+expected - they shouldn't page sentry as errors. Other download failures still should.
+See GH #571."""
+
+import pytest
+from rnet.exceptions import TimeoutError as RnetTimeoutError
+
+from opennem.core.parsers.aemo import nemweb
+
+
+def test_timeout_error_logs_as_warning(monkeypatch: pytest.MonkeyPatch) -> None:
+    levels: list[str] = []
+    monkeypatch.setattr(nemweb.logger, "warning", lambda *a, **kw: levels.append("warning"))
+    monkeypatch.setattr(nemweb.logger, "error", lambda *a, **kw: levels.append("error"))
+
+    nemweb._log_download_error("https://nemweb.com.au/some.zip", RnetTimeoutError("TimedOut"))
+
+    assert levels == ["warning"]
+
+
+def test_other_download_error_logs_as_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    levels: list[str] = []
+    monkeypatch.setattr(nemweb.logger, "warning", lambda *a, **kw: levels.append("warning"))
+    monkeypatch.setattr(nemweb.logger, "error", lambda *a, **kw: levels.append("error"))
+
+    nemweb._log_download_error("https://nemweb.com.au/some.zip", Exception("Failed to download file: Status code 500"))
+
+    assert levels == ["error"]


### PR DESCRIPTION
closes #571

## root cause
the nemweb crawler cluster pages sentry with errors that are already caught + recovered:
- rooftop 404 (5FP, ~500 events): a missing interval at the trailing edge of the 14d live-check window maps to a file that has rolled off CURRENT, so the fetch 404s every 30min forever. it re-queues the same dead interval every run because get_crawler_missing_intervals only fills from CURRENT (archive/catchup owns the real backfill), and each attempt logs at error.
- next_day_dispatch download timeouts (52E/5FW) + 'no records inserted' (50N): transient/benign, logged at error -> noisy sentry issues.

## fix
- `_handle_fetch_error` (opennem/crawlers/nemweb.py): on a 404, once the interval is older than 3 days (rolled off CURRENT for good), record a records=0 crawl_history row under the crawler's own name. get_crawler_missing_intervals filters `where ch.inserted_records is null`, so the interval drops out of the missing set and stops being re-queued here. the interval recorded is exactly `entry.aemo_interval_date.date` — the same value get_files_aemo_intervals matched against the grid — so the join lines up. archive/catchup (separate crawler_name) is unaffected and still backfills it. 404 log -> warning.
- `_log_download_error` (opennem/core/parsers/aemo/nemweb.py): rnet download timeouts -> warning.
- 'no records inserted' -> warning.

## notes
- age boundary uses server-local now vs the AEST-naive interval (~10h imprecision on a 3-day threshold, immaterial; no naive/aware crash).
- rnet timeout downgrade covers rnet.exceptions.TimeoutError; some body-timeout variants may still log at error (not a regression).

## test
tests/crawlers/test_nemweb_fetch_error_handling.py + tests/parsers/test_aemo_nemweb_download_errors.py: 404 age-out writes history only past the rolloff age, non-404 stays error, timeout -> warning. 6 pass. ruff clean.

## review
manual review by orchestrator (age-out mechanism + alignment verified against get_crawler_missing_intervals). codex pass deferred — openai rate limit resets 1pm; will run before merge.