### PR TITLE
fix(aggregates): fill rooftop solar forward to core-gen edge (#579)

### DIFF
--- a/opennem/aggregates/market_summary.py
+++ b/opennem/aggregates/market_summary.py
@@ -97,20 +97,50 @@ async def _get_market_summary_data(
         -- balancing_summary) excluded ALL rooftop, so demand_gross and generation_renewable
         -- silently omitted rooftop for all of history (GH #558). We map rooftop to parent
         -- network 'NEM' so it joins the NEM market rows by region.
-        SELECT
-            time_bucket_gapfill('5 minutes', fs.interval, :start_time_window, :end_time) as interval,
-            'NEM' as network_id,
-            f.network_region,
-            interpolate(avg(fs.generated)) as rooftop_solar
-        FROM facility_scada fs
-        JOIN units u ON fs.facility_code = u.code
-        JOIN facilities f ON u.station_id = f.id
-        WHERE fs.interval BETWEEN :start_time_window AND :end_time
-            AND u.fueltech_id = 'solar_rooftop'
-            AND fs.is_forecast = false
-            AND f.network_id IN ('AEMO_ROOFTOP', 'OPENNEM_ROOFTOP_BACKFILL')
-            AND f.network_region IN (SELECT network_region FROM regions)
-        GROUP BY 1, f.network_region
+        --
+        -- Rooftop is a 30-min feed and lags the 5-min core-generation / demand feed.
+        -- The interior of the series is interpolated between the half-hourly points as
+        -- before. But interpolate() has no future anchor past the last real reading, so
+        -- the trailing edge collapsed to NULL (-> 0 via COALESCE below) while demand and
+        -- core generation kept moving forward, inflecting demand_gross and
+        -- renewable_proportion (#579). For that trailing edge we instead carry the last
+        -- real value forward (locf) up to one 30-min block (+25 min) so rooftop reaches
+        -- the core-gen edge without fabricating a whole missing interval. When rooftop
+        -- lags a full block the single freshest bucket is intentionally left at 0
+        -- rather than invented; the API serves NULL-not-0 at that settling edge
+        -- (#575/#577) so it doesn't inflect. The :start_time_window lookback (1h) seeds
+        -- both accessors before :start_time.
+        SELECT interval, network_id, network_region, rooftop_solar
+        FROM (
+            SELECT
+                interval,
+                'NEM' as network_id,
+                network_region,
+                CASE
+                    WHEN rooftop_interp IS NOT NULL THEN rooftop_interp
+                    WHEN interval <= max(real_interval) OVER (PARTITION BY network_region)
+                                     + interval '25 minutes'
+                        THEN rooftop_locf
+                    ELSE NULL
+                END as rooftop_solar
+            FROM (
+                SELECT
+                    time_bucket_gapfill('5 minutes', fs.interval, :start_time_window, :end_time) as interval,
+                    f.network_region,
+                    interpolate(avg(fs.generated)) as rooftop_interp,
+                    locf(avg(fs.generated)) as rooftop_locf,
+                    max(fs.interval) as real_interval
+                FROM facility_scada fs
+                JOIN units u ON fs.facility_code = u.code
+                JOIN facilities f ON u.station_id = f.id
+                WHERE fs.interval BETWEEN :start_time_window AND :end_time
+                    AND u.fueltech_id = 'solar_rooftop'
+                    AND fs.is_forecast = false
+                    AND f.network_id IN ('AEMO_ROOFTOP', 'OPENNEM_ROOFTOP_BACKFILL')
+                    AND f.network_region IN (SELECT network_region FROM regions)
+                GROUP BY 1, f.network_region
+            ) rooftop_gapfilled
+        ) rooftop_bounded
     ),
     renewable_data AS (
         -- Renewable generation including battery discharge and pumps, excluding TUMUT3

--- a/opennem/aggregates/unit_intervals.py
+++ b/opennem/aggregates/unit_intervals.py
@@ -39,6 +39,13 @@ from opennem.utils.dates import get_last_completed_interval_for_network
 
 logger = logging.getLogger("opennem.aggregates.unit_intervals")
 
+# Rooftop solar (AEMO_ROOFTOP) publishes on a 30-minute cadence and lags the 5-min
+# core-generation feed. To carry it forward onto the 5-min grid up to the core-gen
+# edge (#579) we scan back one+ rooftop interval so locf has a seed at the window
+# start, and limit the carry-forward to a single 30-min block past the last real
+# reading so we never fabricate a whole missing interval.
+_ROOFTOP_LOOKBACK = timedelta(minutes=35)
+
 
 def _monitor_memory_usage() -> float:
     """Monitor and log memory usage, trigger GC if needed.
@@ -122,30 +129,68 @@ async def _get_unit_interval_data(
         GROUP BY 1, 2, 3
     ),
     filled_solar_data AS (
+        -- Rooftop solar is a 30-min feed that lags the 5-min core-generation feed.
+        -- We partition it onto the 5-min grid and carry the last real reading
+        -- forward (locf) up to the core-gen edge (:end_time) so it doesn't drop out
+        -- early and inflect downstream emissions / renewable_proportion (#579).
+        -- Bounds:
+        --   * scan back :solar_start_time (one+ 30-min interval before the window)
+        --     so locf has a seed at :start_time even when the last real reading
+        --     predates the window;
+        --   * min_real_interval drops leading gap buckets before the first real
+        --     reading (pre-existing behaviour);
+        --   * max_real_interval + 25 min limits the carry-forward to a single 30-min
+        --     block so we never fabricate a whole missing interval. When rooftop lags
+        --     a full block (core edge = last_real + 30 min) the single freshest bucket
+        --     is intentionally left absent rather than invented; the API serves
+        --     NULL-not-0 at that settling edge (#575/#577) so it doesn't inflect.
         SELECT
-            time_bucket_gapfill('5 minutes', fs.interval) as interval,
-            fs.network_id,
-            f.network_region,
-            f.code as facility_code,
-            u.code as unit_code,
-            u.status_id,
-            u.fueltech_id,
-            'solar' as fueltech_group_id,
-            TRUE as renewable,
-            locf(coalesce(round(sum(fs.generated), 4), 0)) as generated,
-            locf(coalesce(round(sum(fs.energy) / (12 / (60 / n.interval_size)), 4), 0)) as energy
-        FROM
-            facility_scada fs
-        JOIN units u ON fs.facility_code = u.code
-        JOIN facilities f ON u.station_id = f.id
-        JOIN network n on fs.network_id = n.code
-        WHERE
-            fs.is_forecast IS FALSE
-            AND u.fueltech_id in ('solar_rooftop')
-            AND fs.interval >= :start_time
-            AND fs.interval <= :end_time
-            {network_where_clause}
-        GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, n.interval_size
+            interval,
+            network_id,
+            network_region,
+            facility_code,
+            unit_code,
+            status_id,
+            fueltech_id,
+            fueltech_group_id,
+            renewable,
+            generated,
+            energy
+        FROM (
+            SELECT
+                *,
+                min(real_interval) OVER (PARTITION BY unit_code) as min_real_interval,
+                max(real_interval) OVER (PARTITION BY unit_code) as max_real_interval
+            FROM (
+                SELECT
+                    time_bucket_gapfill('5 minutes', fs.interval, :solar_start_time, :end_time) as interval,
+                    fs.network_id,
+                    f.network_region,
+                    f.code as facility_code,
+                    u.code as unit_code,
+                    u.status_id,
+                    u.fueltech_id,
+                    'solar' as fueltech_group_id,
+                    TRUE as renewable,
+                    locf(coalesce(round(sum(fs.generated), 4), 0)) as generated,
+                    locf(coalesce(round(sum(fs.energy) / (12 / (60 / n.interval_size)), 4), 0)) as energy,
+                    max(fs.interval) as real_interval
+                FROM
+                    facility_scada fs
+                JOIN units u ON fs.facility_code = u.code
+                JOIN facilities f ON u.station_id = f.id
+                JOIN network n on fs.network_id = n.code
+                WHERE
+                    fs.is_forecast IS FALSE
+                    AND u.fueltech_id in ('solar_rooftop')
+                    AND fs.interval >= :solar_start_time
+                    AND fs.interval <= :end_time
+                    {network_where_clause}
+                GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, n.interval_size
+            ) solar_gapfilled
+        ) solar_bounded
+        WHERE interval >= min_real_interval
+            AND interval <= max_real_interval + interval '25 minutes'
     ),
     facility_data as (
         SELECT
@@ -252,7 +297,14 @@ async def _get_unit_interval_data(
     ORDER BY 1,2,3,4,5
     """)
 
-    result = await session.execute(query, {"start_time": start_time_naive, "end_time": end_time_naive})
+    result = await session.execute(
+        query,
+        {
+            "start_time": start_time_naive,
+            "end_time": end_time_naive,
+            "solar_start_time": start_time_naive - _ROOFTOP_LOOKBACK,
+        },
+    )
     return result.fetchall()
 
 
@@ -316,30 +368,68 @@ async def _stream_unit_interval_data(
         GROUP BY 1, 2, 3
     ),
     filled_solar_data AS (
+        -- Rooftop solar is a 30-min feed that lags the 5-min core-generation feed.
+        -- We partition it onto the 5-min grid and carry the last real reading
+        -- forward (locf) up to the core-gen edge (:end_time) so it doesn't drop out
+        -- early and inflect downstream emissions / renewable_proportion (#579).
+        -- Bounds:
+        --   * scan back :solar_start_time (one+ 30-min interval before the window)
+        --     so locf has a seed at :start_time even when the last real reading
+        --     predates the window;
+        --   * min_real_interval drops leading gap buckets before the first real
+        --     reading (pre-existing behaviour);
+        --   * max_real_interval + 25 min limits the carry-forward to a single 30-min
+        --     block so we never fabricate a whole missing interval. When rooftop lags
+        --     a full block (core edge = last_real + 30 min) the single freshest bucket
+        --     is intentionally left absent rather than invented; the API serves
+        --     NULL-not-0 at that settling edge (#575/#577) so it doesn't inflect.
         SELECT
-            time_bucket_gapfill('5 minutes', fs.interval) as interval,
-            fs.network_id,
-            f.network_region,
-            f.code as facility_code,
-            u.code as unit_code,
-            u.status_id,
-            u.fueltech_id,
-            'solar' as fueltech_group_id,
-            TRUE as renewable,
-            locf(coalesce(round(sum(fs.generated), 4), 0)) as generated,
-            locf(coalesce(round(sum(fs.energy) / (12 / (60 / n.interval_size)), 4), 0)) as energy
-        FROM
-            facility_scada fs
-        JOIN units u ON fs.facility_code = u.code
-        JOIN facilities f ON u.station_id = f.id
-        JOIN network n on fs.network_id = n.code
-        WHERE
-            fs.is_forecast IS FALSE
-            AND u.fueltech_id in ('solar_rooftop')
-            AND fs.interval >= :start_time
-            AND fs.interval <= :end_time
-            {network_where_clause}
-        GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, n.interval_size
+            interval,
+            network_id,
+            network_region,
+            facility_code,
+            unit_code,
+            status_id,
+            fueltech_id,
+            fueltech_group_id,
+            renewable,
+            generated,
+            energy
+        FROM (
+            SELECT
+                *,
+                min(real_interval) OVER (PARTITION BY unit_code) as min_real_interval,
+                max(real_interval) OVER (PARTITION BY unit_code) as max_real_interval
+            FROM (
+                SELECT
+                    time_bucket_gapfill('5 minutes', fs.interval, :solar_start_time, :end_time) as interval,
+                    fs.network_id,
+                    f.network_region,
+                    f.code as facility_code,
+                    u.code as unit_code,
+                    u.status_id,
+                    u.fueltech_id,
+                    'solar' as fueltech_group_id,
+                    TRUE as renewable,
+                    locf(coalesce(round(sum(fs.generated), 4), 0)) as generated,
+                    locf(coalesce(round(sum(fs.energy) / (12 / (60 / n.interval_size)), 4), 0)) as energy,
+                    max(fs.interval) as real_interval
+                FROM
+                    facility_scada fs
+                JOIN units u ON fs.facility_code = u.code
+                JOIN facilities f ON u.station_id = f.id
+                JOIN network n on fs.network_id = n.code
+                WHERE
+                    fs.is_forecast IS FALSE
+                    AND u.fueltech_id in ('solar_rooftop')
+                    AND fs.interval >= :solar_start_time
+                    AND fs.interval <= :end_time
+                    {network_where_clause}
+                GROUP BY 1, 2, 3, 4, 5, 6, 7, 8, 9, n.interval_size
+            ) solar_gapfilled
+        ) solar_bounded
+        WHERE interval >= min_real_interval
+            AND interval <= max_real_interval + interval '25 minutes'
     ),
     facility_data as (
         SELECT
@@ -445,7 +535,11 @@ async def _stream_unit_interval_data(
         AND cd.interval < :end_time
     """
 
-    params = {"start_time": start_time_naive, "end_time": end_time_naive}
+    params = {
+        "start_time": start_time_naive,
+        "end_time": end_time_naive,
+        "solar_start_time": start_time_naive - _ROOFTOP_LOOKBACK,
+    }
 
     # Use server-side cursor for more efficient streaming
     order_clause = "ORDER BY cd.interval, cd.network_id, cd.network_region, cd.facility_code, cd.unit_code"

--- a/tests/test_rooftop_fill_forward.py
+++ b/tests/test_rooftop_fill_forward.py
@@ -1,0 +1,114 @@
+"""Rooftop solar must be carried forward to the core-generation edge (#579).
+
+solar_rooftop (AEMO_ROOFTOP) is a 30-min feed that lags the 5-min core-generation /
+demand / price feeds. We partition it onto the 5-min grid for the aggregate joins.
+Previously the partition ended at the last obtained 30-min reading:
+
+  - unit_intervals: the solar gapfill had no explicit finish and, in the narrow
+    incremental window, no real reading to seed locf (the last 30-min reading fell
+    before the window start), so rooftop simply stopped early.
+  - market_summary: interpolate() has no future anchor past the last real reading, so
+    the trailing edge collapsed to NULL -> 0.
+
+Either way core generation / demand kept moving forward while rooftop dropped out,
+inflecting emissions and renewable_proportion at the bleeding edge.
+
+The fix carries the last real reading forward (locf) up to the core-gen edge, bounded
+to a single 30-min block (+25 min) past the last real reading so we never fabricate a
+whole missing interval (that interior-gap case is #580, handled separately).
+
+These are source-level guards (inspect.getsource) because the queries are local text()
+built inside the aggregate functions and executed against a TimescaleDB session — there
+is no returned SQL string to assert on without a live connection. Whitespace is
+collapsed so the assertions survive reindentation / line-wrap changes.
+"""
+
+import inspect
+from datetime import timedelta
+
+from opennem.aggregates.market_summary import _get_market_summary_data
+from opennem.aggregates.unit_intervals import (
+    _ROOFTOP_LOOKBACK,
+    _get_unit_interval_data,
+    _stream_unit_interval_data,
+)
+
+
+def _collapse(fn) -> str:
+    """Function source with all runs of whitespace collapsed to single spaces."""
+    return " ".join(inspect.getsource(fn).split())
+
+
+# --- unit_intervals ---------------------------------------------------------
+
+_UNIT_INTERVAL_QUERY_FNS = [_get_unit_interval_data, _stream_unit_interval_data]
+
+
+def test_unit_intervals_solar_gapfill_extends_to_end_with_lookback_seed() -> None:
+    for fn in _UNIT_INTERVAL_QUERY_FNS:
+        src = _collapse(fn)
+        # gapfill must have an explicit window [solar_start_time, end_time] so locf can
+        # carry the last reading forward to the core-gen edge (implicit bounds truncated
+        # rooftop at the last real reading in the narrow incremental window).
+        assert "time_bucket_gapfill('5 minutes', fs.interval, :solar_start_time, :end_time)" in src, (
+            f"{fn.__name__}: rooftop gapfill must use explicit :solar_start_time/:end_time bounds (#579)"
+        )
+        # locf carries the 30-min reading across the 5-min grid and past the last reading.
+        assert "locf(coalesce(round(sum(fs.generated), 4), 0)) as generated" in src, (
+            f"{fn.__name__}: rooftop generated must be locf() carried forward (#579)"
+        )
+
+
+def test_unit_intervals_solar_fill_is_bounded_to_one_block() -> None:
+    for fn in _UNIT_INTERVAL_QUERY_FNS:
+        src = _collapse(fn)
+        # per-unit last real reading, used to bound the carry-forward
+        assert "max(real_interval) OVER (PARTITION BY unit_code) as max_real_interval" in src, (
+            f"{fn.__name__}: must compute per-unit max real interval to bound the fill (#579)"
+        )
+        # never carry more than a single 30-min block past the last real reading
+        assert "interval <= max_real_interval + interval '25 minutes'" in src, (
+            f"{fn.__name__}: carry-forward must be bounded to +25 min (one 30-min block) (#579)"
+        )
+        # leading gap buckets before the first real reading are dropped (pre-existing)
+        assert "interval >= min_real_interval" in src, (
+            f"{fn.__name__}: must drop leading gap buckets before the first real reading (#579)"
+        )
+
+
+def test_unit_intervals_passes_solar_start_lookback() -> None:
+    for fn in _UNIT_INTERVAL_QUERY_FNS:
+        src = _collapse(fn)
+        assert '"solar_start_time": start_time_naive - _ROOFTOP_LOOKBACK' in src, (
+            f"{fn.__name__}: must bind solar_start_time = start - _ROOFTOP_LOOKBACK to seed locf (#579)"
+        )
+
+
+def test_rooftop_lookback_covers_one_rooftop_interval() -> None:
+    # Must look back at least one full 30-min rooftop interval so the last real reading
+    # before the window is captured as the locf seed; +5 min margin.
+    assert _ROOFTOP_LOOKBACK >= timedelta(minutes=30), "rooftop lookback must cover one 30-min interval (#579)"
+
+
+# --- market_summary ---------------------------------------------------------
+
+
+def test_market_summary_rooftop_interpolates_interior_and_locf_tail() -> None:
+    src = _collapse(_get_market_summary_data)
+    # interior stays interpolated between the half-hourly points (unchanged)
+    assert "interpolate(avg(fs.generated)) as rooftop_interp" in src, (
+        "market_summary rooftop interior must remain interpolate() (#579)"
+    )
+    # trailing edge carries the last real value forward (locf) where interpolate has no
+    # future anchor
+    assert "locf(avg(fs.generated)) as rooftop_locf" in src, "market_summary rooftop trailing edge must locf() forward (#579)"
+
+
+def test_market_summary_rooftop_fill_is_bounded_to_one_block() -> None:
+    src = _collapse(_get_market_summary_data)
+    assert "WHEN rooftop_interp IS NOT NULL THEN rooftop_interp" in src, (
+        "market_summary must prefer the interpolated interior value when present (#579)"
+    )
+    assert (
+        "WHEN interval <= max(real_interval) OVER (PARTITION BY network_region) + interval '25 minutes' THEN rooftop_locf"
+    ) in src, "market_summary rooftop carry-forward must be bounded to +25 min (one 30-min block) (#579)"


### PR DESCRIPTION
closes #579

## problem

`solar_rooftop` (network `AEMO_ROOFTOP`) is a 30-min feed. we partition it to the 5-min grid for the aggregate joins, but it stopped at the last obtained 30-min reading while core generation / demand / price kept moving forward. that left bleeding-edge intervals with 0/absent rooftop while everything else advanced, inflecting emissions and renewable_proportion (the screenshot in the issue).

two code paths, same symptom:

- `unit_intervals.py` `filled_solar_data`: gapfill had no explicit finish and the solar scan started at `:start_time`. timescaledb infers gapfill bounds from the where clause, so over a wide window with the real reading inside, locf carried fine. but the production incremental path runs a narrow window `[date_from=last_processed+5min, date_to=NEM latest]`; when the last 30-min reading fell before `date_from` there was no locf seed in the window, so rooftop emitted zero rows. over successive runs stored rooftop ends at the last real reading.
- `market_summary.py` `rooftop_data`: already scans back 1h but uses `interpolate()`, which has no future anchor past the last real reading, so the trailing edge collapsed to null -> 0 via `COALESCE`. `demand_gross = demand_total + rooftop_solar` and `generation_renewable = renewable_generation + rooftop_solar`, so losing rooftop at the edge inflects renewable_proportion (served from market_summary).

## fix

carry the last real reading forward (locf) to the core-gen edge, bounded to a single 30-min block (+25min) past the last real reading so a whole missing interval is never fabricated.

- `unit_intervals.py`: added `_ROOFTOP_LOOKBACK = timedelta(minutes=35)`. solar cte gapfills over explicit `[:solar_start_time, :end_time]`, tracks `max(fs.interval) as real_interval`, computes per-unit `min/max_real_interval` in a wrapping subquery, then filters `interval >= min_real_interval AND interval <= max_real_interval + interval '25 minutes'`. `:solar_start_time = start - _ROOFTOP_LOOKBACK` seeds locf from the reading before the window. applied identically to both `_get_unit_interval_data` and `_stream_unit_interval_data`. the outer `cd.interval >= :start_time` trims the lookback rows (seed-only).
- `market_summary.py` `rooftop_data`: keeps `interpolate()` for the interior; adds `locf()` + `max(fs.interval)` and a `CASE` that prefers the interpolated value, else uses locf when `interval <= max(real_interval) OVER (PARTITION BY network_region) + interval '25 minutes'`, else null. reuses the existing 1h `:start_time_window` as the seed.

## edge cases

- **interior gaps untouched (that's #580):** the bound compares against the global per-unit/region max real interval, so interior buckets (`interval < global max`) always pass and are still carried / interpolated as before. only true trailing-edge buckets hit the +25min clip.
- **never past core gen:** gapfill finish is `:end_time` (= NEM latest completed interval in the live path) and the fill only moves toward that edge. the outer where trims seed rows before `:start_time`.
- **bleeding-edge value (#575/#577):** unchanged. this only touches the source tables; the api still caps live `date_end` at `max(interval)` and serves null-not-0 for proportion metrics. when rooftop lags a full block the single freshest bucket is intentionally left absent/0 (not invented) — noted in a comment.
- **backfill chunk boundaries:** the +25min clip only affects buckets past the chunk's global last real reading; historically-continuous rooftop keeps the boundary covered, and the next chunk re-derives via its own lookback (ReplacingMergeTree upsert by version).

## verified (read-only on dev)

- reproduced the truncation: old narrow window `[12:05,12:20)` -> 0 rooftop rows (last reading 12:00 < 12:05, no seed).
- new `_get_unit_interval_data` over `[11:50,12:20)`: rooftop(NSW1) reaches 12:15 (= solar_utility core-gen edge), carrying the 12:00 value 2937.436.
- clip demo (last real capped 13:00, window to 13:40, +25=13:25): unit_intervals drops rows past 13:25; market_summary returns null past 13:25 — never a second block.
- market_summary interior interpolation preserved (12:25 interpolated to 2712 between 12:00=2937 and 12:30=2667).
- tests: 6 new source-guard tests + existing price-locf/gapfill = 17 passed. ruff format + check clean.

## tests

source-level guards (`inspect.getsource` + whitespace collapse), matching the existing `test_market_summary_price_locf.py` precedent — the queries are local `text()` executed against timescaledb, so there's no returned sql to assert on without a live connection. guards pin the gapfill bounds + locf, the +25min bound, the min_real lower bound, the solar_start lookback binding, lookback >= 30min, and the market_summary interpolate-interior + locf-tail case.
