### PR TITLE
fix(crawler): handle new aemo archive filename format in mms crawlers

### DIFF
--- a/opennem/core/parsers/aemo/filenames.py
+++ b/opennem/core/parsers/aemo/filenames.py
@@ -10,7 +10,14 @@ from opennem.schema.network import NetworkSchema
 
 logger = logging.getLogger("openne.core.parsers.aemo_filename")
 
+# legacy scheme: PUBLIC_DVD_DISPATCHREGIONSUM_202408010000.zip
 __aemo_filename_re = re.compile(r"(?P<filename>[a-zA-Z\_]+)_(?P<date>\d{6,14})_?(?P<interval>\d{8,16})?\.(zip|csv)")
+
+# new archive scheme (aemo, from 2024-08): PUBLIC_ARCHIVE#DISPATCHREGIONSUM#FILE01#202408010000.zip
+# the '#' separators may appear url-encoded as %23 in hrefs
+__aemo_filename_archive_re = re.compile(
+    r"(?P<filename>[a-zA-Z0-9\_#%]+?)(?:#|%23)(?P<date>\d{8,14})(?:_(?P<interval>\d{8,16}))?\.(zip|csv)"
+)
 
 
 class AEMODataBucketSize(enum.Enum):
@@ -63,7 +70,9 @@ def parse_aemo_filename_datetimes(dtimestr: str, network: NetworkSchema | None =
 def parse_aemo_filename(filename: str) -> AEMOMMSFilename:
     """Takes an AEMO filename and parses it into it's components"""
 
-    filename_components = re.search(__aemo_filename_re, filename.strip())
+    filename_components = re.search(__aemo_filename_re, filename.strip()) or re.search(
+        __aemo_filename_archive_re, filename.strip()
+    )
 
     if not filename_components:
         raise Exception(f"Could not parse filename {filename}")

--- a/opennem/crawlers/mms.py
+++ b/opennem/crawlers/mms.py
@@ -37,6 +37,14 @@ def get_mms_archive_url(year: int, month: int) -> str:
     return MMS_ARCHIVE_URL_FORMAT.format(year=year, month=month)
 
 
+def mms_filename_filter(table_name: str) -> str:
+    """Build a filename filter matching an MMS table across both AEMO archive naming schemes:
+    legacy PUBLIC_DVD_<TABLE>_<date>.zip and the new (2024-08+) PUBLIC_ARCHIVE#<TABLE>#FILE01#<date>.zip.
+    The '#' separator may appear url-encoded as %23 in hrefs."""
+    sep = r"(?:_|#|%23)"
+    return rf".*{sep}{table_name}{sep}.*"
+
+
 async def run_aemo_mms_crawl(
     crawler: CrawlerDefinition,
     run_fill: bool = True,
@@ -146,7 +154,7 @@ AEMOMMSDispatchInterconnector = CrawlerDefinition(
     priority=CrawlerPriority.high,
     schedule=CrawlerSchedule.live,
     name="au.mms.interconnector_res",
-    filename_filter=".*_DISPATCHINTERCONNECTORRES_.*",
+    filename_filter=mms_filename_filter("DISPATCHINTERCONNECTORRES"),
     network=NetworkNEM,
     bucket_size=AEMODataBucketSize.month,
     # limit=1,
@@ -158,7 +166,7 @@ AEMOMMSDispatchPrice = CrawlerDefinition(
     priority=CrawlerPriority.high,
     schedule=CrawlerSchedule.live,
     name="au.mms.dispatch_price",
-    filename_filter=".*_DISPATCHPRICE_.*",
+    filename_filter=mms_filename_filter("DISPATCHPRICE"),
     network=NetworkNEM,
     bucket_size=AEMODataBucketSize.month,
     processor=run_aemo_mms_crawl,
@@ -169,7 +177,7 @@ AEMOMMSDispatchRegionsum = CrawlerDefinition(
     priority=CrawlerPriority.high,
     schedule=CrawlerSchedule.live,
     name="au.mms.dispatch_regionsum",
-    filename_filter=".*_DISPATCHREGIONSUM_.*",
+    filename_filter=mms_filename_filter("DISPATCHREGIONSUM"),
     network=NetworkNEM,
     bucket_size=AEMODataBucketSize.month,
     processor=run_aemo_mms_crawl,
@@ -180,7 +188,7 @@ AEMOMMSTradingPrice = CrawlerDefinition(
     priority=CrawlerPriority.high,
     schedule=CrawlerSchedule.live,
     name="au.mms.trading_price",
-    filename_filter=".*_TRADINGPRICE_.*",
+    filename_filter=mms_filename_filter("TRADINGPRICE"),
     network=NetworkNEM,
     bucket_size=AEMODataBucketSize.month,
     processor=run_aemo_mms_crawl,
@@ -191,7 +199,7 @@ AEMOMMSTradingRegionsum = CrawlerDefinition(
     priority=CrawlerPriority.high,
     schedule=CrawlerSchedule.live,
     name="au.mms.trading_regionsum",
-    filename_filter=".*_TRADINGREGIONSUM_.*",
+    filename_filter=mms_filename_filter("TRADINGREGIONSUM"),
     network=NetworkNEM,
     bucket_size=AEMODataBucketSize.month,
     processor=run_aemo_mms_crawl,
@@ -202,7 +210,7 @@ AEMOMMSDispatchScada = CrawlerDefinition(
     priority=CrawlerPriority.high,
     schedule=CrawlerSchedule.live,
     name="au.mms.dispatch_scada",
-    filename_filter=".*_DISPATCH_UNIT_SCADA.*",
+    filename_filter=mms_filename_filter("DISPATCH_UNIT_SCADA"),
     network=NetworkNEM,
     bucket_size=AEMODataBucketSize.month,
     processor=run_aemo_mms_crawl,
@@ -213,7 +221,7 @@ AEMOMMSMeterDataGenDuid = CrawlerDefinition(
     priority=CrawlerPriority.high,
     schedule=CrawlerSchedule.live,
     name="au.mms.meterdata_gen_duid",
-    filename_filter=".*_METERDATA_GEN_DUID_.*",
+    filename_filter=mms_filename_filter("METERDATA_GEN_DUID"),
     network=NetworkNEM,
     bucket_size=AEMODataBucketSize.month,
     processor=run_aemo_mms_crawl,

--- a/tests/test_parsers_aemo_filenames.py
+++ b/tests/test_parsers_aemo_filenames.py
@@ -66,9 +66,47 @@ def test_parse_aemo_filename_datetimes(dtstring: str, expected: datetime) -> Non
                 "interval": "20211002",
             },
         ),
+        # new aemo archive scheme (2024-08+): PUBLIC_ARCHIVE#<TABLE>#FILE01#<date>.zip
+        (
+            "PUBLIC_ARCHIVE#DISPATCHREGIONSUM#FILE01#202408010000.zip",
+            {
+                "filename": "PUBLIC_ARCHIVE#DISPATCHREGIONSUM#FILE01",
+                "date": datetime.fromisoformat("2024-08-01T00:00:00"),
+                "interval": None,
+            },
+        ),
+        # same scheme with the '#' url-encoded as %23
+        (
+            "PUBLIC_ARCHIVE%23DISPATCHPRICE%23FILE01%23202408010000.zip",
+            {
+                "filename": "PUBLIC_ARCHIVE%23DISPATCHPRICE%23FILE01",
+                "date": datetime.fromisoformat("2024-08-01T00:00:00"),
+                "interval": None,
+            },
+        ),
     ],
 )
 def test_parse_aemo_filename(filename: str, components: AEMOMMSFilename) -> None:
     comp_result = parse_aemo_filename(filename)
     components_model = AEMOMMSFilename(**components)  # type: ignore
     assert comp_result == components_model, "Components match"
+
+
+@pytest.mark.parametrize(
+    ["filename", "matches"],
+    [
+        ("PUBLIC_DVD_DISPATCHREGIONSUM_202408010000.zip", True),
+        ("PUBLIC_ARCHIVE#DISPATCHREGIONSUM#FILE01#202408010000.zip", True),
+        ("PUBLIC_ARCHIVE%23DISPATCHREGIONSUM%23FILE01%23202408010000.zip", True),
+        ("PUBLIC_DVD_TRADINGREGIONSUM_202408010000.zip", False),
+        ("PUBLIC_ARCHIVE#TRADINGREGIONSUM#FILE01#202408010000.zip", False),
+    ],
+)
+def test_mms_filename_filter(filename: str, matches: bool) -> None:
+    """the mms filename filter matches a table across both aemo archive naming schemes"""
+    import re
+
+    from opennem.crawlers.mms import mms_filename_filter
+
+    pattern = mms_filename_filter("DISPATCHREGIONSUM")
+    assert bool(re.match(pattern, filename)) is matches


### PR DESCRIPTION
fixes #593

aemo changed the MMSDM archive filename scheme from 2024-08:
- old: `PUBLIC_DVD_DISPATCHREGIONSUM_202408010000.zip`
- new: `PUBLIC_ARCHIVE#DISPATCHREGIONSUM#FILE01#202408010000.zip` (served as `%23` in hrefs)

two delimiter-sensitive regexes broke on the new separators:

1. crawler `filename_filter` (`opennem/crawlers/mms.py`) — `.*_<TABLE>_.*` matched underscores only, so the dirlisting filter dropped every new-format file and `process_mms_url` returned `None`. any historical MMS backfill of 2024-08+ silently did nothing.
2. `parse_aemo_filename` (`opennem/core/parsers/aemo/filenames.py`) — required `_` before the date, returned `None`, so `aemo_interval_date` was never set and crawler history never recorded → re-crawl thrash.

## changes
- `mms_filename_filter(table)` helper builds a delimiter-agnostic filter (`_` | `#` | `%23`); applied to all 7 mms crawler defs
- additive archive-scheme fallback regex in `parse_aemo_filename` (existing legacy path untouched → zero regression risk)
- tests for both schemes incl `%23`-encoded names + the filter helper

## validation
- 16 filename/filter unit tests pass
- validated end-to-end against the live 2024-08 aemo dirlisting: server serves hrefs as `%23`, filter now matches the 1 DISPATCHREGIONSUM file, interval date parses to 2024-08-01 (history recording works)

no impact on live data (that flows via the nemweb current-data crawler); this only affects the monthly MMS archive crawlers / historical backfills.