### PR TITLE
fix(docker): give appuser a home dir so chromium can render social cards

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,8 +73,10 @@ RUN apt-get update \
 ENV CHROME_BIN=/usr/bin/chromium
 ENV CHROMIUM_FLAGS="--no-sandbox --headless --disable-gpu"
 
-# Create non-root user for security
-RUN groupadd -r appuser && useradd -r -g appuser appuser
+# Create non-root user for security.
+# -m is required: chromium >= 150 derives its crashpad database path from $HOME,
+# and aborts on startup ("--database is required", exit 133) when it doesn't exist.
+RUN groupadd -r appuser && useradd -r -m -g appuser appuser
 
 # Copy venv from builder
 COPY --from=builder $PYSETUP_PATH $PYSETUP_PATH


### PR DESCRIPTION
## what

one line: `useradd -r -g appuser appuser` → `useradd -r -m -g appuser appuser`

## why

the whole social pipeline has been dead on prod since **2026-07-07** — no weekly summaries, no milestone cards, no tweets.

chromium 150 derives its crashpad database path from `$HOME`. `appuser` was created without `-m`, so `/home/appuser` never existed → empty `--database` → `chrome_crashpad_handler` aborts → SIGTRAP, **exit 133**, no PNG written. html2image doesn't pass `check=True`, so the failure surfaces later as `RuntimeError: chromium failed to render ...`.

latent since the Mar-2026 Dockerfile. `apt-get install chromium` is unpinned, so the 2026-07-07 prod image rebuild silently upgraded the browser and detonated it. chromium <150 tolerated the missing HOME.

## evidence

first prod failure is **9 minutes** after the 2026-07-07 10:27 UTC deploy:

| when (UTC) | env | what |
|---|---|---|
| 2026-07-06 23:00 | production | WEM wk27 — last success |
| 2026-07-07 07:56 | production | last milestone card success |
| **2026-07-07 10:27** | — | **prod deploy / image rebuild** |
| 2026-07-07 10:36 | production | first card failure |
| 2026-07-12 21:00 | production | NEM wk28 failed |
| 2026-07-13 23:00 | production | WEM wk28 failed |
| 2026-07-19 21:00 | production | NEM wk29 failed |
| 2026-07-20 23:00 | production | WEM wk29 failed |

sentry: BACKEND-5ZA (weekly summary), BACKEND-5ZF/5ZG/5ZH/5ZP (milestone cards). note dev and prod run the same crons ~2s apart so their events group into one issue — the env tag is what separates them.

## verification

repro'd the prod production stage in docker, arm64 and amd64 (so not an emulation artifact):

- **fail (133)** — every flag workaround: `--headless=new|old`, `--disable-crashpad`, `--disable-breakpad`, `--disable-features=Crashpad`, `--crash-dumps-dir`, `--no-zygote --single-process`, `--user-data-dir`
- **pass (exit 0, valid PNG)** — `useradd -r -m -g appuser appuser`

## notes

- no app-code change needed; the `--no-sandbox` flags from #583 are correct and already deployed
- `ENV CHROMIUM_FLAGS` on line 74 is dead — html2image never reads it. left alone to keep this diff to one line, but worth deleting separately
- unpinned `chromium` means the next rebuild can move the browser again. worth pinning or vendoring a known build
- weeks 28 and 29 are permanently missed. wk29 (13–19 Jul) NEM + WEM were generated manually and are pending approval in slack; wk28 not backfilled