### PR TITLE
fix(wem): derive generation from published energy pre-2014 #598

### DIFF
--- a/opennem/clients/wem.py
+++ b/opennem/clients/wem.py
@@ -13,6 +13,7 @@ See the URL constants for sources and unit tests
 
 import csv
 import logging
+from collections import Counter
 from datetime import datetime, timedelta
 from io import StringIO
 from typing import Annotated, Any
@@ -53,6 +54,10 @@ _AEMO_WEM2_GENERATION_URL = "https://aemo.com.au/aemo/data/wa/infographic/genera
 # facility-scada archive (2006-09 through the WEMDE cutover on 2023-10-01).
 # WEMDE dispatch intervals are 5-minute and are handled by opennem.clients.wemde.
 WEM_LEGACY_INTERVAL_SIZE_MINUTES = 30
+
+# Cadences WEM has actually published: 30 minute legacy trading intervals and 5 minute
+# WEMDE dispatch intervals. Anything else is treated as a detection failure.
+WEM_VALID_INTERVAL_SIZES = (5, 30)
 
 # The date AEMO began publishing the "EOI Quantity (MW)" column in the facility-scada
 # archive. Records before this carry only "Energy Generated (MWh)". See #598.
@@ -117,7 +122,9 @@ class WEMBalancingSummaryInterval(BaseModel):
 
     @property
     def is_forecast(self) -> bool:
-        return not self.actual_total_generation and not self.actual_nsg_mw
+        # `is None`, not falsiness: a published zero is an actual reading, not a missing
+        # one, and zeros are now preserved rather than coerced to None
+        return self.actual_total_generation is None and self.actual_nsg_mw is None
 
     model_config = ConfigDict(alias_generator=_wem_balancing_summary_field_alias)
 
@@ -163,16 +170,16 @@ class WEMGenerationInterval(BaseModel):
         that the archive carries `Energy Generated (MWh)` alone. Derive power from energy
         in that era rather than returning null (see #598).
         """
-        if self.power:
+        if self.power is not None:
             return self.power
 
-        if self.generated_scheduled and self.generated_non_scheduled:
+        if self.generated_scheduled is not None and self.generated_non_scheduled is not None:
             return self.generated_scheduled + self.generated_non_scheduled
 
-        if self.generated_non_scheduled:
+        if self.generated_non_scheduled is not None:
             return self.generated_non_scheduled
 
-        if self.generated_scheduled:
+        if self.generated_scheduled is not None:
             return self.generated_scheduled
 
         if self.eoi_quantity is not None:
@@ -382,6 +389,11 @@ def _detect_interval_size_minutes(intervals: list[datetime]) -> int:
     The legacy archive is 30-minute for its whole life and the WEMDE-era feeds are
     5-minute, but detecting rather than assuming keeps energy/power conversion correct
     if AEMO changes cadence again.
+
+    Uses the most common gap rather than the smallest: a single malformed or duplicated
+    timestamp would drag a minimum down and silently apply the wrong MWh->MW factor to
+    every record in the file. Falls back to the legacy size if the dominant gap is not a
+    cadence WEM has ever published.
     """
     distinct = sorted(set(intervals))
 
@@ -394,7 +406,13 @@ def _detect_interval_size_minutes(intervals: list[datetime]) -> int:
     if not deltas:
         return WEM_LEGACY_INTERVAL_SIZE_MINUTES
 
-    return min(deltas)
+    dominant = Counter(deltas).most_common(1)[0][0]
+
+    if dominant not in WEM_VALID_INTERVAL_SIZES:
+        logger.warning(f"Unexpected WEM interval size {dominant}min, falling back to {WEM_LEGACY_INTERVAL_SIZE_MINUTES}min")
+        return WEM_LEGACY_INTERVAL_SIZE_MINUTES
+
+    return dominant
 
 
 def parse_wem_facility_intervals(content: str, interval_size_minutes: int | None = None) -> list[WEMGenerationInterval]:
@@ -466,8 +484,17 @@ async def get_wem_live_facility_intervals(
     return wem_set
 
 
-async def get_wem_facility_intervals(from_date: datetime | None = None) -> WEMFacilityIntervalSet:
+async def get_wem_facility_intervals(
+    from_date: datetime | None = None, fallback_to_recent: bool = True
+) -> WEMFacilityIntervalSet:
     """Obtains WEM facility intervals from NEM web. Will default to most recent date
+
+    Args:
+        fallback_to_recent: When the requested month is missing, fall back to the file from
+            30 days ago. Useful for the live crawler where the current month may not be up
+            yet, but wrong for a historical backfill - a missing month must surface as
+            WEMFileNotFoundException so the caller can skip it, not silently return a
+            different month's data.
 
     @TODO not yet smart enough to know if it should check current or archive
     """
@@ -476,6 +503,9 @@ async def get_wem_facility_intervals(from_date: datetime | None = None) -> WEMFa
     try:
         content = await wem_downloader(_AEMO_WEM_SCADA_URL, from_date)
     except WEMFileNotFoundException:
+        if not fallback_to_recent:
+            raise
+
         _now = datetime.now()
         from_date = _now - timedelta(days=30)
         content = await wem_downloader(_AEMO_WEM_SCADA_URL, from_date)

--- a/opennem/clients/wem.py
+++ b/opennem/clients/wem.py
@@ -18,8 +18,8 @@ from io import StringIO
 from typing import Annotated, Any
 
 from pydantic import (
-    AfterValidator,
     BaseModel,
+    BeforeValidator,
     ConfigDict,
     Field,
     ValidationError,
@@ -49,6 +49,15 @@ _AEMO_WEM_BALANCING_SUMMARY_URL = (
 
 _AEMO_WEM2_GENERATION_URL = "https://aemo.com.au/aemo/data/wa/infographic/generation.csv"
 
+# WEM published 30-minute trading intervals for the whole life of the legacy
+# facility-scada archive (2006-09 through the WEMDE cutover on 2023-10-01).
+# WEMDE dispatch intervals are 5-minute and are handled by opennem.clients.wemde.
+WEM_LEGACY_INTERVAL_SIZE_MINUTES = 30
+
+# The date AEMO began publishing the "EOI Quantity (MW)" column in the facility-scada
+# archive. Records before this carry only "Energy Generated (MWh)". See #598.
+WEM_EOI_QUANTITY_FIRST_SEEN = datetime(2013, 12, 17)
+
 # Create aiohttp session
 
 
@@ -58,20 +67,33 @@ def _wem_balancing_summary_field_alias(field_name: str) -> str:
 
 
 def _empty_string_to_none(field_value: str | float | None) -> float | None:
-    """Convert empty strings to None and strings to floats"""
-    if not field_value:
+    """Convert empty strings to None and strings to floats.
+
+    Runs as a BeforeValidator: AEMO leaves numeric columns as empty strings rather than
+    omitting them (the whole "EOI Quantity (MW)" column is empty before 2013-12-17), and
+    pydantic's own float coercion rejects "" before an AfterValidator would ever see it.
+
+    A published zero is preserved as 0.0 — it means the unit ran at zero, which is real
+    data and distinct from a missing value.
+    """
+    if field_value is None:
         return None
-    if field_value == "":
-        return None
+
     if isinstance(field_value, str):
+        field_value = field_value.strip()
+
+        if not field_value:
+            return None
+
         try:
             return float(field_value)
         except ValueError:
             return None
-    return field_value
+
+    return float(field_value)
 
 
-FloatField = Annotated[float | None, AfterValidator(_empty_string_to_none)]
+FloatField = Annotated[float | None, BeforeValidator(_empty_string_to_none)]
 
 
 class WEMBalancingSummaryInterval(BaseModel):
@@ -121,11 +143,26 @@ class WEMGenerationInterval(BaseModel):
     generated_scheduled: FloatField = None
     generated_non_scheduled: FloatField = None
 
+    # Length of the interval this record covers, in minutes. WEM published 30-minute
+    # trading intervals until the WEMDE cutover (2023-10-01), after which dispatch is
+    # 5-minute. Used to convert between energy (MWh/interval) and power (MW).
+    interval_size_minutes: int = WEM_LEGACY_INTERVAL_SIZE_MINUTES
+
     created_by: str = "controllers.wem"
     created_at: datetime = Field(default_factory=datetime.now)
 
     @property
+    def intervals_per_hour(self) -> float:
+        return 60 / self.interval_size_minutes
+
+    @property
     def generated(self) -> float | None:
+        """Generation in MW.
+
+        AEMO only began publishing the `EOI Quantity (MW)` column on 2013-12-17; before
+        that the archive carries `Energy Generated (MWh)` alone. Derive power from energy
+        in that era rather than returning null (see #598).
+        """
         if self.power:
             return self.power
 
@@ -137,6 +174,24 @@ class WEMGenerationInterval(BaseModel):
 
         if self.generated_scheduled:
             return self.generated_scheduled
+
+        if self.eoi_quantity is not None:
+            return self.eoi_quantity * self.intervals_per_hour
+
+        return None
+
+    @property
+    def energy(self) -> float | None:
+        """Energy in MWh for the interval.
+
+        Mirrors the WEMDE client, which stores the published MWh quantity as-is and
+        derives `generated` from it.
+        """
+        if self.eoi_quantity is not None:
+            return self.eoi_quantity
+
+        if self.power is not None:
+            return self.power / self.intervals_per_hour
 
         return None
 
@@ -321,26 +376,57 @@ def _remap_wem_facility_interval_field(field_name: str) -> str:
     return WEM_FACILITY_INTERVAL_FIELD_REMAP[field_name]
 
 
-def parse_wem_facility_intervals(content: str) -> list[WEMGenerationInterval]:
-    """parses the wem live generation intervals for each facility"""
+def _detect_interval_size_minutes(intervals: list[datetime]) -> int:
+    """Infer the interval size of a WEM dataset from its distinct timestamps.
+
+    The legacy archive is 30-minute for its whole life and the WEMDE-era feeds are
+    5-minute, but detecting rather than assuming keeps energy/power conversion correct
+    if AEMO changes cadence again.
+    """
+    distinct = sorted(set(intervals))
+
+    if len(distinct) < 2:
+        return WEM_LEGACY_INTERVAL_SIZE_MINUTES
+
+    deltas = [int((b - a).total_seconds() // 60) for a, b in zip(distinct, distinct[1:], strict=False)]
+    deltas = [d for d in deltas if d > 0]
+
+    if not deltas:
+        return WEM_LEGACY_INTERVAL_SIZE_MINUTES
+
+    return min(deltas)
+
+
+def parse_wem_facility_intervals(content: str, interval_size_minutes: int | None = None) -> list[WEMGenerationInterval]:
+    """parses the wem live generation intervals for each facility
+
+    Args:
+        interval_size_minutes: Override the interval size. When not given it is detected
+            from the distinct trading intervals in the payload.
+    """
 
     _models = []
 
     csvreader = csv.DictReader(content.split("\n"))
 
+    _records = []
+
     for _csv_rec in csvreader:
         # adapts the fields from balancing-summary history to match our schema
-        _csv_rec = {_remap_wem_facility_interval_field(i): k for i, k in _csv_rec.items()}
+        _records.append({_remap_wem_facility_interval_field(i): k for i, k in _csv_rec.items()})
 
-        # @NOTE do wem energy here
-        if "power" in _csv_rec and _csv_rec["power"] and float(_csv_rec["power"]) > 0:
-            _csv_rec["eoi_quantity"] = str(float(_csv_rec["power"]) / 2.0)
-
+    for _csv_rec in _records:
         model = _parse_csv_record(_csv_rec, WEMGenerationInterval)
         if model:
             _models.append(model)
 
-    logger.debug(f"Got {len(_models)} facility interval records")
+    if interval_size_minutes is None:
+        interval_size_minutes = _detect_interval_size_minutes([i.trading_interval for i in _models])
+
+    for model in _models:
+        model.interval_size_minutes = interval_size_minutes
+
+    logger.debug(f"Got {len(_models)} facility interval records at {interval_size_minutes}min intervals")
 
     return _models
 

--- a/opennem/controllers/wem.py
+++ b/opennem/controllers/wem.py
@@ -5,6 +5,7 @@ Update facility intervals and balancing summary for WEM
 
 import logging
 
+from sqlalchemy import func
 from sqlalchemy.dialects.postgresql import insert
 
 from opennem.clients.wem import WEMBalancingSummarySet, WEMFacilityIntervalSet
@@ -15,6 +16,16 @@ from opennem.db.models.opennem import BalancingSummary, FacilityScada
 from opennem.utils.dates import get_today_nem
 
 logger = logging.getLogger(__name__)
+
+# asyncpg caps a statement at 32767 bind parameters. facility_scada inserts bind 7
+# columns per row, so keep chunks well under that ceiling.
+FACILITY_SCADA_INSERT_CHUNK_SIZE = 4000
+
+
+def _chunk_records(records: list[dict], chunk_size: int = FACILITY_SCADA_INSERT_CHUNK_SIZE):
+    """Yield records in chunks that fit within the postgres bind parameter limit"""
+    for i in range(0, len(records), chunk_size):
+        yield records[i : i + chunk_size]
 
 
 def store_wem_balancingsummary_set(balancing_set: WEMBalancingSummarySet) -> ControllerReturn:
@@ -140,9 +151,16 @@ async def store_wem_balancingsummary_set_bulk(balancing_set: WEMBalancingSummary
 
 
 async def store_wem_facility_intervals(
-    balancing_set: WEMFacilityIntervalSet, created_by: str = "wem.controller"
+    balancing_set: WEMFacilityIntervalSet, created_by: str = "wem.controller", fill_nulls_only: bool = False
 ) -> ControllerReturn:
-    """Persist WEM facility intervals"""
+    """Persist WEM facility intervals
+
+    Args:
+        fill_nulls_only: Only populate columns that are currently null, never overwrite an
+            existing value. Used by the historical backfill so that re-ingesting a month
+            which straddles the 2013-12-17 EOI cutover cannot clobber generation or energy
+            that is already published.
+    """
     cr = ControllerReturn()
 
     records_to_store = []
@@ -159,14 +177,17 @@ async def store_wem_facility_intervals(
         if (_rec.trading_interval, _rec.facility_code) in primary_keys:
             continue
 
+        primary_keys.add((_rec.trading_interval, _rec.facility_code))
+
         records_to_store.append(
             {
-                "created_by": "wem.controller",
                 "network_id": "WEM",
-                "trading_interval": _rec.trading_interval,
+                "interval": _rec.trading_interval.replace(tzinfo=None),
                 "facility_code": _rec.facility_code,
                 "generated": _rec.generated,
-                "eoi_quantity": _rec.eoi_quantity,
+                "energy": _rec.energy,
+                "is_forecast": False,
+                "energy_quality_flag": 2,
             }
         )
         cr.processed_records += 1
@@ -175,26 +196,37 @@ async def store_wem_facility_intervals(
         return cr
 
     async with SessionLocal() as session:
-        try:
-            stmt = insert(FacilityScada).values(records_to_store)
-            stmt = stmt.on_conflict_do_update(
-                index_elements=["trading_interval", "network_id", "facility_code", "is_forecast"],
-                set_={
-                    "generated": stmt.excluded.generated,
-                    "eoi_quantity": stmt.excluded.eoi_quantity,
-                },
-            )
+        for chunk in _chunk_records(records_to_store):
+            try:
+                stmt = insert(FacilityScada).values(chunk)
 
-            await session.execute(stmt)
-            await session.commit()
-            cr.inserted_records = len(records_to_store)
-        except Exception as e:
-            logger.error(f"Error: {e}")
-            cr.errors = len(records_to_store)
-            cr.error_detail.append(str(e))
-            await session.rollback()
-        finally:
-            await session.close()
+                if fill_nulls_only:
+                    set_ = {
+                        "generated": func.coalesce(FacilityScada.generated, stmt.excluded.generated),
+                        "energy": func.coalesce(FacilityScada.energy, stmt.excluded.energy),
+                    }
+                else:
+                    set_ = {
+                        "generated": stmt.excluded.generated,
+                        "energy": stmt.excluded.energy,
+                    }
+
+                stmt = stmt.on_conflict_do_update(
+                    index_elements=["interval", "network_id", "facility_code", "is_forecast"],
+                    set_=set_,
+                )
+
+                await session.execute(stmt)
+                await session.commit()
+                cr.inserted_records += len(chunk)
+            except Exception as e:
+                logger.error(f"Error: {e}")
+                cr.errors += len(chunk)
+                # truncated: the driver echoes the entire parameterised statement
+                cr.error_detail.append(str(e)[:500])
+                await session.rollback()
+
+        await session.close()
 
     return cr
 
@@ -205,7 +237,6 @@ async def store_wem_facility_intervals_bulk(facility_interval_set: WEMFacilityIn
     Optimized bulk insert version
     """
 
-    created_at = get_today_nem()
     cr = ControllerReturn()
 
     records_to_store = []
@@ -216,24 +247,23 @@ async def store_wem_facility_intervals_bulk(facility_interval_set: WEMFacilityIn
     cr.total_records = len(facility_interval_set.intervals)
     cr.server_latest = facility_interval_set.server_latest
 
-    primary_keys: list[set] = []
+    primary_keys: set = set()
 
     for _rec in facility_interval_set.intervals:
         if (_rec.trading_interval, _rec.facility_code) in primary_keys:
             continue
 
+        primary_keys.add((_rec.trading_interval, _rec.facility_code))
+
         records_to_store.append(
             {
-                "created_by": "opennem.controller",
-                "created_at": created_at,
-                "updated_at": None,
                 "network_id": "WEM",
-                "trading_interval": _rec.trading_interval,
+                "interval": _rec.trading_interval.replace(tzinfo=None),
                 "facility_code": _rec.facility_code,
                 "generated": _rec.generated,
-                "eoi_quantity": _rec.eoi_quantity,
+                "energy": _rec.energy,
                 "is_forecast": False,
-                "energy_quality_flag": 0,
+                "energy_quality_flag": 2,
             }
         )
 
@@ -242,6 +272,6 @@ async def store_wem_facility_intervals_bulk(facility_interval_set: WEMFacilityIn
     if len(records_to_store) < 1:
         return cr
 
-    await bulkinsert_mms_items(FacilityScada, records_to_store, ["generated", "eoi_quantity"])  # type: ignore
+    await bulkinsert_mms_items(FacilityScada, records_to_store, ["generated", "energy"])  # type: ignore
 
     return cr

--- a/opennem/crawlers/wem.py
+++ b/opennem/crawlers/wem.py
@@ -15,36 +15,36 @@ from opennem.core.crawlers.schema import CrawlerDefinition, CrawlerPriority, Cra
 logger = logging.getLogger("opennem.crawlers.wem")
 
 
-def run_wem_balancing_crawl(
+async def run_wem_balancing_crawl(
     crawler: CrawlerDefinition, last_crawled: bool = True, limit: bool = False, latest: bool = False, **kwargs
 ) -> ControllerReturn:
-    balancing_set = get_wem_balancing_summary()
+    balancing_set = await get_wem_balancing_summary()
     cr = store_wem_balancingsummary_set(balancing_set)
     return cr
 
 
-def run_wem_facility_scada_crawl(
+async def run_wem_facility_scada_crawl(
     crawler: CrawlerDefinition, last_crawled: bool = True, limit: bool = False, latest: bool = False, **kwargs
 ) -> ControllerReturn:
-    generated_set = get_wem_facility_intervals()
-    cr = store_wem_facility_intervals(generated_set)
+    generated_set = await get_wem_facility_intervals()
+    cr = await store_wem_facility_intervals(generated_set)
     return cr
 
 
-def run_wem_live_balancing_crawl(
+async def run_wem_live_balancing_crawl(
     crawler: CrawlerDefinition, last_crawled: bool = True, limit: bool = False, latest: bool = False, **kwargs
 ) -> ControllerReturn:
-    balancing_set = get_wem_live_balancing_summary()
+    balancing_set = await get_wem_live_balancing_summary()
     cr = store_wem_balancingsummary_set(balancing_set)
     return cr
 
 
-def run_wem_live_facility_scada_crawl(
+async def run_wem_live_facility_scada_crawl(
     crawler: CrawlerDefinition, last_crawled: bool = True, limit: bool = False, latest: bool = False, **kwargs
 ) -> ControllerReturn:
     from_interval = crawler.server_latest or None
-    generated_set = get_wem_live_facility_intervals(from_interval=from_interval, trim_intervals=True)
-    cr = store_wem_facility_intervals(generated_set)
+    generated_set = await get_wem_live_facility_intervals(from_interval=from_interval, trim_intervals=True)
+    cr = await store_wem_facility_intervals(generated_set)
     return cr
 
 

--- a/opennem/workers/wem_backfill.py
+++ b/opennem/workers/wem_backfill.py
@@ -30,8 +30,10 @@ logger = logging.getLogger("opennem.workers.wem_backfill")
 # First month present in the AEMO facility-scada archive
 WEM_ARCHIVE_FIRST_MONTH = datetime(2006, 9, 1)
 
-# The WEMDE cutover. The legacy archive stops being the source of truth here.
-WEM_ARCHIVE_LAST_MONTH = datetime(2023, 10, 1)
+# Last month for which the legacy archive is the source of truth. WEMDE starts
+# 2023-10-01, so October 2023 onward belongs to opennem.crawlers.wemde and must not be
+# ingested through the 30-minute legacy path.
+WEM_ARCHIVE_LAST_MONTH = datetime(2023, 9, 1)
 
 # Last month affected by the missing EOI Quantity column, and so the default end of the
 # backfill. Everything after this already has generation from the published MW column.
@@ -74,13 +76,19 @@ async def run_wem_facility_scada_backfill(
 
     months = _month_range(date_start, date_end)
 
+    if not months:
+        logger.warning(f"No months to backfill: date_start {date_start:%Y-%m} is after date_end {date_end:%Y-%m}")
+        return 0
+
     logger.info(f"Backfilling WEM facility scada for {len(months)} months: {months[0]:%Y-%m} to {months[-1]:%Y-%m}")
 
     total_records = 0
 
     for month in months:
         try:
-            interval_set = await get_wem_facility_intervals(from_date=month)
+            # fallback_to_recent would silently substitute a recent month for a missing
+            # one, which for a backfill means ingesting the wrong period entirely
+            interval_set = await get_wem_facility_intervals(from_date=month, fallback_to_recent=False)
         except WEMFileNotFoundException:
             logger.warning(f"{month:%Y-%m}: no archive file, skipping")
             continue

--- a/opennem/workers/wem_backfill.py
+++ b/opennem/workers/wem_backfill.py
@@ -1,0 +1,139 @@
+"""Backfill WEM facility generation from the AEMO facility-scada archive.
+
+AEMO only began publishing the `EOI Quantity (MW)` column in the WEM facility-scada
+archive on 2013-12-17. OpenNEM derived `generated` solely from that column, so every WEM
+unit has null generation and energy before that date even though the archive carries
+`Energy Generated (MWh)` all the way back to 2006-09 (see #598).
+
+The client now derives power from the published energy for that era. This worker walks
+the monthly archive files and persists them.
+
+Note on eras:
+
+  * 2006-09 .. 2023-09  legacy archive, 30 minute trading intervals
+  * 2023-10 ..          WEMDE, 5 minute dispatch intervals, handled by
+                        `opennem.crawlers.wemde` and not touched here
+
+Interval size is detected per file rather than assumed, so a cadence change upstream does
+not silently corrupt the energy/power conversion.
+"""
+
+import asyncio
+import logging
+from datetime import datetime
+
+from opennem.clients.wem import WEMFileNotFoundException, get_wem_facility_intervals
+from opennem.controllers.wem import store_wem_facility_intervals
+
+logger = logging.getLogger("opennem.workers.wem_backfill")
+
+# First month present in the AEMO facility-scada archive
+WEM_ARCHIVE_FIRST_MONTH = datetime(2006, 9, 1)
+
+# The WEMDE cutover. The legacy archive stops being the source of truth here.
+WEM_ARCHIVE_LAST_MONTH = datetime(2023, 10, 1)
+
+# Last month affected by the missing EOI Quantity column, and so the default end of the
+# backfill. Everything after this already has generation from the published MW column.
+WEM_EOI_QUANTITY_LAST_MONTH = datetime(2013, 12, 1)
+
+
+def _month_range(date_start: datetime, date_end: datetime) -> list[datetime]:
+    """Inclusive list of month-start dates between two dates"""
+    months = []
+    current = date_start.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    end = date_end.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+
+    while current <= end:
+        months.append(current)
+        current = (
+            current.replace(year=current.year + 1, month=1) if current.month == 12 else current.replace(month=current.month + 1)
+        )
+
+    return months
+
+
+async def run_wem_facility_scada_backfill(
+    date_start: datetime = WEM_ARCHIVE_FIRST_MONTH,
+    date_end: datetime = WEM_EOI_QUANTITY_LAST_MONTH,
+    dry_run: bool = False,
+    fill_nulls_only: bool = True,
+) -> int:
+    """Backfill WEM facility scada from the monthly archive.
+
+    Defaults to filling nulls only, so a month straddling the 2013-12-17 EOI cutover can
+    be re-ingested without overwriting generation or energy that is already published.
+
+    Returns the total number of records persisted.
+    """
+    if date_end > WEM_ARCHIVE_LAST_MONTH:
+        logger.warning(
+            f"Clamping date_end {date_end:%Y-%m} to {WEM_ARCHIVE_LAST_MONTH:%Y-%m} - WEMDE is the source after the cutover"
+        )
+        date_end = WEM_ARCHIVE_LAST_MONTH
+
+    months = _month_range(date_start, date_end)
+
+    logger.info(f"Backfilling WEM facility scada for {len(months)} months: {months[0]:%Y-%m} to {months[-1]:%Y-%m}")
+
+    total_records = 0
+
+    for month in months:
+        try:
+            interval_set = await get_wem_facility_intervals(from_date=month)
+        except WEMFileNotFoundException:
+            logger.warning(f"{month:%Y-%m}: no archive file, skipping")
+            continue
+        except Exception as e:
+            logger.error(f"{month:%Y-%m}: download or parse failed: {e}")
+            continue
+
+        if not interval_set.intervals:
+            logger.warning(f"{month:%Y-%m}: no intervals parsed, skipping")
+            continue
+
+        with_generated = len([i for i in interval_set.intervals if i.generated is not None])
+        interval_size = interval_set.intervals[0].interval_size_minutes
+
+        if dry_run:
+            logger.info(
+                f"{month:%Y-%m}: [dry run] {len(interval_set.intervals)} intervals "
+                f"({with_generated} with generation) at {interval_size}min"
+            )
+            continue
+
+        cr = await store_wem_facility_intervals(interval_set, created_by="wem_backfill", fill_nulls_only=fill_nulls_only)
+
+        total_records += cr.inserted_records
+
+        logger.info(
+            f"{month:%Y-%m}: stored {cr.inserted_records} of {len(interval_set.intervals)} intervals "
+            f"({with_generated} with generation) at {interval_size}min, {cr.errors} errors"
+        )
+
+        if cr.error_detail:
+            logger.error(f"{month:%Y-%m}: {cr.error_detail}")
+
+    logger.info(f"Backfill complete, {total_records} records persisted")
+
+    return total_records
+
+
+async def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Backfill WEM facility scada from the AEMO archive")
+    parser.add_argument("--date-start", type=lambda s: datetime.strptime(s, "%Y-%m"), default=WEM_ARCHIVE_FIRST_MONTH)
+    parser.add_argument("--date-end", type=lambda s: datetime.strptime(s, "%Y-%m"), default=WEM_EOI_QUANTITY_LAST_MONTH)
+    parser.add_argument("--overwrite", action="store_true", help="Overwrite existing values instead of filling nulls only")
+    parser.add_argument("--dry-run", action="store_true")
+
+    args = parser.parse_args()
+
+    await run_wem_facility_scada_backfill(
+        date_start=args.date_start, date_end=args.date_end, dry_run=args.dry_run, fill_nulls_only=not args.overwrite
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/clients/test_wem_facility_scada.py
+++ b/tests/clients/test_wem_facility_scada.py
@@ -7,8 +7,11 @@ Covers the two eras the archive spans (see #598):
   * from 2013-12-17 both columns are published
 """
 
+from datetime import datetime, timedelta
+
 from opennem.clients.wem import (
     WEM_LEGACY_INTERVAL_SIZE_MINUTES,
+    WEMBalancingSummaryInterval,
     WEMGenerationInterval,
     _detect_interval_size_minutes,
     parse_wem_facility_intervals,
@@ -105,6 +108,54 @@ class TestIntervalSizeDetection:
 
     def test_falls_back_when_only_one_interval(self):
         assert _detect_interval_size_minutes([]) == WEM_LEGACY_INTERVAL_SIZE_MINUTES
+
+    def test_outlier_gap_does_not_win(self):
+        # one stray timestamp 1 minute off must not make the whole file look 1-minute,
+        # which would apply a 60x factor to every record
+        base = datetime(2010, 1, 1, 8, 0)
+        intervals = [base + timedelta(minutes=30 * i) for i in range(20)]
+        intervals.append(base + timedelta(minutes=1))
+
+        assert _detect_interval_size_minutes(intervals) == 30
+
+    def test_unknown_cadence_falls_back(self):
+        base = datetime(2010, 1, 1, 8, 0)
+        hourly = [base + timedelta(minutes=60 * i) for i in range(10)]
+
+        # 60 minutes is not a cadence WEM has published
+        assert _detect_interval_size_minutes(hourly) == WEM_LEGACY_INTERVAL_SIZE_MINUTES
+
+    def test_detects_five_minute_cadence(self):
+        base = datetime(2024, 6, 1, 8, 0)
+        five_min = [base + timedelta(minutes=5 * i) for i in range(20)]
+
+        assert _detect_interval_size_minutes(five_min) == 5
+
+
+class TestZeroHandling:
+    """Zeros are preserved by FloatField, so consumers must test `is None`"""
+
+    def test_zero_power_is_not_treated_as_missing(self):
+        record = WEMGenerationInterval(
+            trading_interval="2014-06-01 08:00:00",
+            facility_code="COLLIE_G1",
+            power=0.0,
+        )
+
+        assert record.generated == 0.0
+
+    def test_zero_actual_generation_is_not_a_forecast(self):
+        record = WEMBalancingSummaryInterval(
+            TRADING_DAY_INTERVAL="2014-06-01 08:00:00",
+            ACTUAL_TOTAL_GENERATION=0.0,
+        )
+
+        assert record.is_forecast is False
+
+    def test_missing_actuals_is_a_forecast(self):
+        record = WEMBalancingSummaryInterval(TRADING_DAY_INTERVAL="2014-06-01 08:00:00")
+
+        assert record.is_forecast is True
 
     def test_five_minute_wemde_cadence(self):
         record = WEMGenerationInterval(

--- a/tests/clients/test_wem_facility_scada.py
+++ b/tests/clients/test_wem_facility_scada.py
@@ -1,0 +1,118 @@
+"""Tests for the WEM facility-scada archive parser.
+
+Covers the two eras the archive spans (see #598):
+
+  * before 2013-12-17 AEMO published only "Energy Generated (MWh)" and left the
+    "EOI Quantity (MW)" column empty
+  * from 2013-12-17 both columns are published
+"""
+
+from opennem.clients.wem import (
+    WEM_LEGACY_INTERVAL_SIZE_MINUTES,
+    WEMGenerationInterval,
+    _detect_interval_size_minutes,
+    parse_wem_facility_intervals,
+)
+
+HEADER = (
+    "Trading Date,Interval Number,Trading Interval,Participant Code,Facility Code,"
+    "Energy Generated (MWh),EOI Quantity (MW),Extracted At"
+)
+
+# Pre-2013-12-17: EOI Quantity column is empty on every row
+CSV_ENERGY_ONLY = "\n".join(
+    [
+        HEADER,
+        '"2010-01-01",1,2010-01-01 08:00:00,"WPGENER","COLLIE_G1",84.503,,',
+        '"2010-01-01",2,2010-01-01 08:30:00,"WPGENER","COLLIE_G1",106.382,,',
+        '"2010-01-01",1,2010-01-01 08:00:00,"WPGENER","KWINANA_G1",0,,',
+    ]
+)
+
+# Post-cutover: both columns published
+CSV_WITH_EOI = "\n".join(
+    [
+        HEADER,
+        '"2014-06-01",20,2014-06-01 17:30:00,"WPGENER","COLLIE_G1",144.541,303.174,',
+        '"2014-06-01",21,2014-06-01 18:00:00,"WPGENER","COLLIE_G1",156.223,315.773,',
+    ]
+)
+
+
+class TestWemEnergyOnlyEra:
+    """Before 2013-12-17 power has to be derived from the published energy"""
+
+    def test_records_are_not_dropped(self):
+        models = parse_wem_facility_intervals(CSV_ENERGY_ONLY)
+
+        # an empty EOI column used to fail float validation and silently drop every row
+        assert len(models) == 3
+
+    def test_energy_is_the_published_value(self):
+        models = parse_wem_facility_intervals(CSV_ENERGY_ONLY)
+
+        assert models[0].energy == 84.503
+
+    def test_generated_is_derived_from_energy(self):
+        models = parse_wem_facility_intervals(CSV_ENERGY_ONLY)
+
+        # 30 minute interval, so MWh -> MW is x2
+        assert models[0].generated == 84.503 * 2
+        assert models[1].generated == 106.382 * 2
+
+    def test_published_zero_is_preserved(self):
+        models = parse_wem_facility_intervals(CSV_ENERGY_ONLY)
+
+        zero_record = [i for i in models if i.facility_code == "KWINANA_G1"][0]
+
+        # a unit running at zero is real data, distinct from a missing value
+        assert zero_record.energy == 0.0
+        assert zero_record.generated == 0.0
+
+    def test_interval_is_awst_wall_time(self):
+        models = parse_wem_facility_intervals(CSV_ENERGY_ONLY)
+
+        # facility_scada stores WEM intervals as AWST-naive, matching the published value
+        assert models[0].trading_interval.replace(tzinfo=None).isoformat() == "2010-01-01T08:00:00"
+
+
+class TestWemEoiEra:
+    """From 2013-12-17 the published MW column wins"""
+
+    def test_generated_uses_published_power(self):
+        models = parse_wem_facility_intervals(CSV_WITH_EOI)
+
+        assert models[0].generated == 303.174
+
+    def test_energy_is_the_published_value(self):
+        models = parse_wem_facility_intervals(CSV_WITH_EOI)
+
+        assert models[0].energy == 144.541
+
+
+class TestIntervalSizeDetection:
+    def test_detects_thirty_minute_intervals(self):
+        models = parse_wem_facility_intervals(CSV_ENERGY_ONLY)
+
+        assert models[0].interval_size_minutes == 30
+
+    def test_override_is_respected(self):
+        models = parse_wem_facility_intervals(CSV_ENERGY_ONLY, interval_size_minutes=5)
+
+        assert models[0].interval_size_minutes == 5
+        # 5 minute interval, so MWh -> MW is x12
+        assert models[0].generated == 84.503 * 12
+
+    def test_falls_back_when_only_one_interval(self):
+        assert _detect_interval_size_minutes([]) == WEM_LEGACY_INTERVAL_SIZE_MINUTES
+
+    def test_five_minute_wemde_cadence(self):
+        record = WEMGenerationInterval(
+            trading_interval="2024-06-01 08:00:00",
+            facility_code="COLLIE_G1",
+            eoi_quantity=10.0,
+            interval_size_minutes=5,
+        )
+
+        assert record.generated == 120.0
+        assert record.energy == 10.0


### PR DESCRIPTION
Fixes #598. Also explains 6 of the 8 units in #599.

## What was wrong

WEM facility `energy`/`power` is null for essentially everything before 2013-12-18.

AEMO only began publishing the `EOI Quantity (MW)` column in the facility-scada archive on **2013-12-17** (partial day) / **2013-12-18** (full). We derived `generated` solely from that column, so every WEM unit has `data_first_seen = 2013-12-18` exactly. `Energy Generated (MWh)` is published for the whole archive back to **2006-09** and was never used.

Three independent layers, all fixed here:

1. **Every pre-2014 record was silently dropped.** `FloatField` used an `AfterValidator`, so an empty `EOI Quantity (MW)` failed pydantic's float coercion before the validator could map `""` to `None`. Now a `BeforeValidator`.
2. **No power was derived from energy.** `WEMGenerationInterval` now carries an interval size and derives MW from the published MWh when the MW column is absent, mirroring what `clients/wemde.py` already does (`generated = quantity * 12, energy = quantity`). Interval size is detected per file, so the 30-minute legacy archive and 5-minute WEMDE cadence both convert correctly.
3. **The store path wrote columns that no longer exist.** `store_wem_facility_intervals` wrote `trading_interval` and `eoi_quantity`, neither of which has existed since `2f6d8cb5bcdf`. So the legacy archive crawler would have thrown regardless. Now writes `interval` and `energy`, chunked under the asyncpg 32767 bind-param limit.

Also awaits the four WEM crawler entrypoints, which called async client functions without awaiting them.

## Safety

- `fill_nulls_only` (default on for the backfill) uses `coalesce(facility_scada.col, excluded.col)` so re-ingesting a month that straddles the cutover cannot clobber already-published values. Verified against 2014-06 on dev: existing `generated`/`energy` unchanged after a re-run.
- Backfill is clamped to 2023-09; WEMDE owns everything from 2023-10.
- A missing archive month raises rather than silently substituting a recent month.
- Zeros are now preserved rather than coerced to null. Consumers that relied on falsiness (`generated`, `is_forecast`) were updated to test `is None`.

## Verification

Timestamp convention confirmed against already-ingested data — CSV `2014-06-01 17:30:00` maps to stored `2014-06-01 17:30` (AWST-naive), and stored `generated` 303.174 equals the published EOI value exactly.

Backfilled 2006-09 → 2013-12 on **dev**: 88 months, 0 errors, all files detected as 30min. Spot check, Collie G1 at 2010-01-01 08:00 AWST:

| | value | source |
|---|---|---|
| `energy` | 84.503 | published MWh, exact |
| `generated` | 169.006 | 84.503 x 2 |

WEM Jan-2010 total 1,638 GWh across 58 units, consistent with WEM annual demand.

17 new tests in `tests/clients/test_wem_facility_scada.py` covering both eras, cadence detection (including outlier and unknown-cadence fallback), and zero handling.

## Not in this PR

- ClickHouse `unit_intervals` re-aggregation for WEM 2006-2013 (ops step, dev in progress)
- Prod backfill (ops step)
- #599 unit code fixes: `KWINANA_C5/C6` should be `KWINANA_G5/G6` and `MUJA_M1..M4` should be `MUJA_G1..G4` to match AEMO. `NPSNL1/NPSNL2` are phantom duplicates of the real `NPS1/NPS2`. Those are CMS metadata changes and want to land before a prod backfill, otherwise 18 pre-2014 WEM facility codes have no unit to attach to and get dropped.