### PR TITLE
feat(api): derived commissioning unit status on facilities endpoint

### DIFF
--- a/opennem/api/facilities/router.py
+++ b/opennem/api/facilities/router.py
@@ -24,6 +24,30 @@ from opennem.schema.unit import UnitDispatchType, UnitFueltechGroupType, UnitFue
 router = APIRouter()
 logger = logging.getLogger("opennem.api.facilities")
 
+# a unit is considered commissioning while its maximum observed generation is at or
+# below this proportion of its capacity. Mirrors the OpenElectricity website rule.
+_COMMISSIONING_CAPACITY_THRESHOLD = 0.9
+
+
+def _unit_effective_status(unit: Unit) -> str:
+    """The unit status as served by the API.
+
+    `commissioning` is a derived status: a unit that is operating but has not yet
+    demonstrated near-full output (max observed generation <= 90% of capacity).
+    It is never stored in the database or CMS. Units with no observed generation
+    yet remain `operating` — no data is not evidence of commissioning.
+    """
+    if unit.status_id != UnitStatusType.operating.value:
+        return str(unit.status_id)
+
+    capacity = unit.capacity_maximum or unit.capacity_registered
+
+    if unit.max_generation and capacity:
+        if float(unit.max_generation) / float(capacity) <= _COMMISSIONING_CAPACITY_THRESHOLD:
+            return UnitStatusType.commissioning.value
+
+    return str(unit.status_id)
+
 
 @api_version(major=4)
 @router.get(
@@ -45,7 +69,11 @@ async def get_facilities(
     status_id: Annotated[
         list[UnitStatusType] | None,
         Query(
-            description="Filter by unit operational status. Multi-value: `?status_id=operating&status_id=committed`.",
+            description=(
+                "Filter by unit operational status. Multi-value: `?status_id=operating&status_id=committed`. "
+                "`commissioning` is derived: operating units whose maximum observed generation is <=90% of capacity. "
+                "Such units report `status_id=commissioning` and are excluded from `operating` filters."
+            ),
             examples=[["operating"]],
         ),
     ] = None,
@@ -82,7 +110,9 @@ async def get_facilities(
 
     Filters:
     - facility_code: Filter by one or more facility codes
-    - status_id: Filter by one or more unit statuses (operating, committed, retired)
+    - status_id: Filter by one or more unit statuses (operating, commissioning, committed, retired).
+      commissioning is derived at the API layer: operating units whose maximum observed
+      generation is <=90% of capacity report status_id=commissioning
     - fueltech_id: Filter by one or more unit fuel technology types
     - network_id: Filter by one or more network codes
     - network_region: Filter by network region
@@ -146,7 +176,7 @@ async def get_facilities(
                     unit.approved
                     and not unit.interconnector
                     and unit.fueltech_id not in ["solar_rooftop", "imports", "exports"]
-                    and (status_values is None or unit.status_id in status_values)
+                    and (status_values is None or _unit_effective_status(unit) in status_values)
                     and (fueltech_values is None or unit.fueltech_id in fueltech_values)
                     and (
                         fueltech_group_values is None
@@ -189,7 +219,7 @@ async def get_facilities(
                         code=str(unit.code),
                         code_display=unit.code_display,
                         fueltech_id=UnitFueltechType(unit.fueltech_id),
-                        status_id=UnitStatusType(unit.status_id),
+                        status_id=UnitStatusType(_unit_effective_status(unit)),
                     )
 
                     if unit.capacity_registered:

--- a/opennem/api/facilities/schema.py
+++ b/opennem/api/facilities/schema.py
@@ -54,7 +54,11 @@ class UnitResponseSchema(BaseModel):
         examples=["coal_black"],
     )
     status_id: UnitStatusType = Field(
-        description="Operational status (`operating`, `committed`, `retired`, …).",
+        description=(
+            "Operational status (`operating`, `commissioning`, `committed`, `retired`). "
+            "`commissioning` is derived: an operating unit whose maximum observed generation "
+            "is <=90% of capacity."
+        ),
         examples=["operating"],
     )
     capacity_registered: RoundedFloat2 | None = Field(

--- a/opennem/cms/importer.py
+++ b/opennem/cms/importer.py
@@ -34,6 +34,7 @@ from opennem.core.networks import network_from_network_code
 from opennem.db import get_read_session, get_write_session, retry_on_deadlock
 from opennem.db.models.opennem import Facility, Unit
 from opennem.schema.facility import FacilitySchema
+from opennem.schema.unit import UnitStatusType
 from opennem.workers.facility_data_seen import update_facility_seen_range
 
 logger = logging.getLogger("sanity.importer")
@@ -282,7 +283,10 @@ async def create_or_update_database_facility(facility: FacilitySchema, send_slac
                     code=unit_operational_code,
                     code_display=unit_display_code,
                     fueltech_id=unit.fueltech_id.value if unit.fueltech_id else None,
-                    status_id=unit.status_id.value if unit.status_id else None,
+                    # commissioning is a derived API-only status — never persist it
+                    status_id=(
+                        unit.status_id.value if unit.status_id and unit.status_id != UnitStatusType.commissioning else None
+                    ),
                     dispatch_type=unit.dispatch_type.value if unit.dispatch_type else None,
                     capacity_registered=round(unit.capacity_registered, 2) if unit.capacity_registered else None,
                     capacity_maximum=(
@@ -378,8 +382,13 @@ async def create_or_update_database_facility(facility: FacilitySchema, send_slac
                 record_updated = True
 
             if unit.status_id:
-                unit_db.status_id = unit.status_id.value
-                record_updated = True
+                # commissioning is a derived API-only status — never persist it.
+                # See UnitStatusType.commissioning and api/facilities/router.py
+                if unit.status_id == UnitStatusType.commissioning:
+                    logger.warning(f"Unit {unit.code}: ignoring derived status 'commissioning' from CMS")
+                else:
+                    unit_db.status_id = unit.status_id.value
+                    record_updated = True
 
             if unit.dispatch_type:
                 unit_db.dispatch_type = unit.dispatch_type.value.upper()

--- a/opennem/schema/unit.py
+++ b/opennem/schema/unit.py
@@ -31,11 +31,15 @@ class UnitStatusType(enum.Enum):
     Attributes:
         committed: Approved / under construction; not yet generating.
         operating: Currently dispatching to the market.
+        commissioning: Derived status — operating but not yet demonstrated near-full
+            output (max observed generation <= 90% of capacity). Not stored in the
+            database or CMS; computed at the API layer.
         retired: Permanently decommissioned.
     """
 
     committed = "committed"
     operating = "operating"
+    commissioning = "commissioning"
     retired = "retired"
 
 

--- a/tests/api/test_facilities_commissioning.py
+++ b/tests/api/test_facilities_commissioning.py
@@ -1,0 +1,67 @@
+"""Tests for the derived commissioning unit status (GH openelectricity-typescript#21).
+
+A unit is served as `commissioning` when it is operating but its maximum observed
+generation is <= 90% of capacity. The status is derived at the API layer and never
+stored — mirrors the OpenElectricity website rule.
+"""
+
+from types import SimpleNamespace
+
+from opennem.api.facilities.router import _unit_effective_status
+from opennem.schema.unit import UnitStatusType
+
+
+def _unit(
+    status_id: str = "operating",
+    max_generation: float | None = None,
+    capacity_maximum: float | None = None,
+    capacity_registered: float | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        status_id=status_id,
+        max_generation=max_generation,
+        capacity_maximum=capacity_maximum,
+        capacity_registered=capacity_registered,
+    )
+
+
+def test_operating_at_full_output_stays_operating() -> None:
+    assert _unit_effective_status(_unit(max_generation=95.0, capacity_registered=100.0)) == "operating"
+
+
+def test_operating_below_threshold_is_commissioning() -> None:
+    assert _unit_effective_status(_unit(max_generation=50.0, capacity_registered=100.0)) == "commissioning"
+
+
+def test_exactly_at_threshold_is_commissioning() -> None:
+    assert _unit_effective_status(_unit(max_generation=90.0, capacity_registered=100.0)) == "commissioning"
+
+
+def test_just_above_threshold_is_operating() -> None:
+    assert _unit_effective_status(_unit(max_generation=90.1, capacity_registered=100.0)) == "operating"
+
+
+def test_capacity_maximum_preferred_over_registered() -> None:
+    # 85/110 = 77% of capacity_maximum -> commissioning even though 85/90 > 90% of registered
+    assert _unit_effective_status(_unit(max_generation=85.0, capacity_maximum=110.0, capacity_registered=90.0)) == "commissioning"
+
+
+def test_no_observed_generation_stays_operating() -> None:
+    # no data is not evidence of commissioning
+    assert _unit_effective_status(_unit(max_generation=None, capacity_registered=100.0)) == "operating"
+
+
+def test_no_capacity_stays_operating() -> None:
+    assert _unit_effective_status(_unit(max_generation=50.0)) == "operating"
+
+
+def test_committed_not_derived() -> None:
+    assert _unit_effective_status(_unit(status_id="committed", max_generation=10.0, capacity_registered=100.0)) == "committed"
+
+
+def test_retired_not_derived() -> None:
+    assert _unit_effective_status(_unit(status_id="retired", max_generation=10.0, capacity_registered=100.0)) == "retired"
+
+
+def test_commissioning_enum_member_exists() -> None:
+    assert UnitStatusType("commissioning") is UnitStatusType.commissioning


### PR DESCRIPTION
## Summary

Adds `commissioning` as a queryable and served `status_id` on `/v4/facilities` (openelectricity-typescript#21).

- derived at the API layer: an `operating` unit whose `max_generation` is <=90% of capacity (`capacity_maximum` preferred, else `capacity_registered`) is served as `status_id=commissioning`
- mirrors the website rule (`is-commissioning.js`) so API/SDK consumers see the same classification the site displays
- `status_id=commissioning` filter now works; `operating` filter excludes commissioning units (consistent with the flipped response value)
- never persisted: CMS importer guards both create and update paths against writing the derived status
- units with no observed generation stay `operating` (no data is not commissioning evidence)

## Notes

- response behaviour change: units previously served as `operating` that meet the rule now serve `commissioning`. Existing consumers filtering `status_id=operating` will no longer receive those units.
- the 90% threshold is a heuristic pending the finalised internal definition (per @chienleng on the issue); constant is `_COMMISSIONING_CAPACITY_THRESHOLD`

## Tests

- 10 new unit tests for the derivation (`tests/api/test_facilities_commissioning.py`), all passing
- cms importer tests pass