### PR TITLE
fix(export): scale v3 curtailment energy series to GWh #607

### DIFF
--- a/opennem/api/export/controllers.py
+++ b/opennem/api/export/controllers.py
@@ -441,7 +441,7 @@ async def curtailment_network_region_daily(
     # curtailment based values for VWP
     if stats_curtailment_solar := stats_factory(
         stats=result_curtailment_solar,
-        units=get_unit("curtailment_solar_utility_energy"),
+        units=get_unit("curtailment_solar_utility_energy_giga"),
         network=time_series.network,
         fueltech_group=False,
         fueltech_code="curtailment_solar_utility",
@@ -452,7 +452,7 @@ async def curtailment_network_region_daily(
 
     if stats_curtailment_wind := stats_factory(
         stats=result_curtailment_wind,
-        units=get_unit("curtailment_wind_energy"),
+        units=get_unit("curtailment_wind_energy_giga"),
         network=time_series.network,
         fueltech_group=False,
         fueltech_code="curtailment_wind",

--- a/opennem/core/data/units.json
+++ b/opennem/core/data/units.json
@@ -54,9 +54,15 @@
     },
     {
         "name": "curtailment_solar_utility_energy",
-        "name_alias": "curtailment.solar.utility.energy",
+        "name_alias": "curtailment.solar.utility.energy_mega",
         "unit_type": "energy",
         "unit": "MWh"
+    },
+    {
+        "name": "curtailment_solar_utility_energy_giga",
+        "name_alias": "curtailment.solar.utility.energy",
+        "unit_type": "energy",
+        "unit": "GWh"
     },
     {
         "name": "curtailment_wind",
@@ -66,9 +72,15 @@
     },
     {
         "name": "curtailment_wind_energy",
-        "name_alias": "curtailment.wind.energy",
+        "name_alias": "curtailment.wind.energy_mega",
         "unit_type": "energy",
         "unit": "MWh"
+    },
+    {
+        "name": "curtailment_wind_energy_giga",
+        "name_alias": "curtailment.wind.energy",
+        "unit_type": "energy",
+        "unit": "GWh"
     },
     {
         "name": "energy_gig",

--- a/opennem/queries/curtailment.py
+++ b/opennem/queries/curtailment.py
@@ -29,12 +29,14 @@ def get_network_curtailment_energy_query_analytics(
         network_region_code: Specific network region (optional)
 
     Returns:
-        str: ClickHouse SQL query returning curtailment energy in MWh
+        str: ClickHouse SQL query returning curtailment energy in GWh
 
     Note:
         Only NEM supports curtailment data. WEM has no curtailment data.
         For AU network, only NEM data is queried since WEM has no curtailment.
-        Energy values are stored and returned in MWh.
+        market_summary stores curtailment energy in MWh, but this feeds the v3
+        export where every energy series is GWh (the tracker applies one
+        GWh scale to the whole dataset), so values are scaled down here (#607).
     """
     if network != NetworkNEM:
         raise ValueError(f"Curtailment data is only supported on the NEM network. Got {network.code}")
@@ -70,9 +72,9 @@ def get_network_curtailment_energy_query_analytics(
             {time_bucket}(interval) AS interval,
             network_id,
             {select_region}
-            sum(curtailment_energy_total) AS curtailment_energy_total,
-            sum(curtailment_energy_solar_total) AS curtailment_energy_solar_total,
-            sum(curtailment_energy_wind_total) AS curtailment_energy_wind_total
+            round(sum(curtailment_energy_total) / 1000, 4) AS curtailment_energy_total,
+            round(sum(curtailment_energy_solar_total) / 1000, 4) AS curtailment_energy_solar_total,
+            round(sum(curtailment_energy_wind_total) / 1000, 4) AS curtailment_energy_wind_total
         FROM market_summary FINAL
         WHERE
             network_id = 'NEM'

--- a/tests/queries/test_curtailment.py
+++ b/tests/queries/test_curtailment.py
@@ -1,0 +1,49 @@
+"""Regression tests for #607: v3 export curtailment energy must be GWh.
+
+The v3 static export declares every energy series as GWh and the tracker
+frontend applies one GWh scale to the whole dataset, so the curtailment query
+must scale MWh storage down and the export units must resolve to GWh without
+changing the exported series ids (built from unit name_alias).
+"""
+
+from datetime import datetime
+
+import pytest
+
+from opennem.core.units import get_unit
+from opennem.queries.curtailment import get_network_curtailment_energy_query_analytics
+from opennem.schema.network import NetworkNEM, NetworkWEM
+
+
+def test_curtailment_energy_query_scales_to_gwh() -> None:
+    query = get_network_curtailment_energy_query_analytics(
+        network=NetworkNEM,
+        date_min=datetime(2026, 1, 1),
+        date_max=datetime(2026, 2, 1),
+        network_region_code="VIC1",
+    )
+
+    assert "round(sum(curtailment_energy_total) / 1000, 4)" in query
+    assert "round(sum(curtailment_energy_solar_total) / 1000, 4)" in query
+    assert "round(sum(curtailment_energy_wind_total) / 1000, 4)" in query
+
+
+def test_curtailment_energy_query_rejects_non_nem() -> None:
+    with pytest.raises(ValueError):
+        get_network_curtailment_energy_query_analytics(network=NetworkWEM, date_min=datetime(2026, 1, 1))
+
+
+@pytest.mark.parametrize(
+    "unit_name,alias",
+    [
+        ("curtailment_solar_utility_energy_giga", "curtailment.solar.utility.energy"),
+        ("curtailment_wind_energy_giga", "curtailment.wind.energy"),
+    ],
+)
+def test_curtailment_export_units_are_giga_with_original_alias(unit_name: str, alias: str) -> None:
+    unit = get_unit(unit_name)
+
+    assert unit.unit == "GWh"
+    assert unit.unit_type == "energy"
+    # the alias builds the v3 series id (au.nem.<region>.<alias>) — it must not change
+    assert unit.name_alias == alias


### PR DESCRIPTION
fixes #607

after #605 corrected market_summary energy columns to true MWh, the v3 static export curtailment series (still passing raw values with units MWh) started reading 1000x high on the tracker for >7 day views. the tracker treats every energy series in the v3 dataset as GWh (demand and fueltech energy series are exported as GWh), so curtailment was only displaying correctly before because the stored values were accidentally GWh-scale.

- `queries/curtailment.py`: scale the three curtailment energy sums /1000 to GWh (same pattern as `queries/demand.py`)
- `units.json`: new `curtailment_*_energy_giga` entries (GWh) take the original name_alias so exported series ids (`au.nem.<region>.curtailment.wind.energy` etc) are unchanged; the MWh entries keep their names with `_mega` aliases, mirroring `demand.energy_mega`/`demand.energy_giga`
- `api/export/controllers.py`: use the `_giga` units
- regression tests for the query scaling and unit resolution

v4 API paths (`core/metric.py`, `api/market/schema.py`) are unaffected and stay MWh — verified correct against prod CH (energy col vs avg(MW)x24 ratio 1.0).

previewed on dev CH for VIC1: daily and monthly series now emit GWh-scale values with units GWh under unchanged ids (jul 2026 wind: 166.0141 GWh, matches v4 API 166,014 MWh).