### PR TITLE
fix(api): serve dec 1998 nem data, explicit nulls for interior gaps

### DIFF
--- a/opennem/api/timeseries.py
+++ b/opennem/api/timeseries.py
@@ -173,8 +173,6 @@ def _build_label_key_and_labels(
 
 
 # Intervals with a constant width, where the next bucket is a pure offset from the last.
-# Calendar intervals (1M, 3M, season, 1y, fy) are not here — they are gap-filled against the
-# buckets observed elsewhere in the same response instead of by arithmetic.
 _FIXED_INTERVAL_STEP = {
     Interval.INTERVAL: timedelta(minutes=5),
     Interval.HOUR: timedelta(hours=1),
@@ -182,38 +180,42 @@ _FIXED_INTERVAL_STEP = {
     Interval.WEEK: timedelta(days=7),
 }
 
+# Calendar intervals have no constant width, but every bucket start is month-aligned, so the
+# next one is a whole number of months on from the last.
+_CALENDAR_INTERVAL_MONTHS = {
+    Interval.MONTH: 1,
+    Interval.QUARTER: 3,
+    Interval.SEASON: 3,
+    Interval.YEAR: 12,
+    Interval.FINANCIAL_YEAR: 12,
+}
 
-def _expected_buckets(
-    interval: Interval,
-    first: datetime,
-    last: datetime,
-    observed: Sequence[datetime],
-) -> list[datetime]:
-    """Every bucket that should sit between `first` and `last` inclusive.
 
-    Fixed-width intervals are stepped arithmetically. Calendar intervals have no constant
-    width, so they fall back to the buckets seen anywhere in this response — enough to fill
-    a hole in one series when any sibling series covers that bucket.
-    """
+def _add_months(ts: datetime, months: int) -> datetime:
+    """Advance a month-aligned bucket start by whole months."""
+    month_index = ts.month - 1 + months
+    return ts.replace(year=ts.year + month_index // 12, month=month_index % 12 + 1)
+
+
+def _expected_buckets(interval: Interval, first: datetime, last: datetime) -> list[datetime]:
+    """Every bucket that should sit between `first` and `last` inclusive."""
     step = _FIXED_INTERVAL_STEP.get(interval)
+    months = _CALENDAR_INTERVAL_MONTHS.get(interval)
 
-    if step is None:
-        return [ts for ts in observed if first <= ts <= last]
+    if step is None and months is None:
+        return []
 
     buckets: list[datetime] = []
     ts = first
+
     while ts <= last:
         buckets.append(ts)
-        ts += step
+        ts = ts + step if step is not None else _add_months(ts, months)  # type: ignore[arg-type]
 
     return buckets
 
 
-def _fill_interior_gaps(
-    grouped: dict[str, dict[str, Any]],
-    interval: Interval,
-    all_buckets: Sequence[datetime],
-) -> None:
+def _fill_interior_gaps(grouped: dict[str, dict[str, Any]], interval: Interval) -> None:
     """Insert explicit `(bucket, None)` points for interior buckets a series is missing.
 
     A series that carries no row for a bucket inside its own lifetime is reporting "no data",
@@ -228,7 +230,7 @@ def _fill_interior_gaps(
         if len(data) < 2:
             continue
 
-        expected = _expected_buckets(interval, data[0][0], data[-1][0], all_buckets)
+        expected = _expected_buckets(interval, data[0][0], data[-1][0])
 
         if len(expected) == len(data):
             continue
@@ -301,7 +303,7 @@ def format_timeseries_response(
             logger.warning(f"No grouped results for metric {metric_name}")
             continue
 
-        _fill_interior_gaps(grouped, interval, sorted({ts for g in grouped.values() for ts, _ in g["data"]}))
+        _fill_interior_gaps(grouped, interval)
 
         # date range from actual data
         all_ts = [ts for g in grouped.values() for ts, _ in g["data"]]

--- a/opennem/api/timeseries.py
+++ b/opennem/api/timeseries.py
@@ -7,7 +7,7 @@ time series data across both market and data endpoints.
 
 import logging
 from collections.abc import Sequence
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any
 
 from pydantic import ConfigDict, Field, computed_field, model_validator
@@ -172,6 +172,72 @@ def _build_label_key_and_labels(
     return ("|".join(parts) if parts else "total"), labels
 
 
+# Intervals with a constant width, where the next bucket is a pure offset from the last.
+# Calendar intervals (1M, 3M, season, 1y, fy) are not here — they are gap-filled against the
+# buckets observed elsewhere in the same response instead of by arithmetic.
+_FIXED_INTERVAL_STEP = {
+    Interval.INTERVAL: timedelta(minutes=5),
+    Interval.HOUR: timedelta(hours=1),
+    Interval.DAY: timedelta(days=1),
+    Interval.WEEK: timedelta(days=7),
+}
+
+
+def _expected_buckets(
+    interval: Interval,
+    first: datetime,
+    last: datetime,
+    observed: Sequence[datetime],
+) -> list[datetime]:
+    """Every bucket that should sit between `first` and `last` inclusive.
+
+    Fixed-width intervals are stepped arithmetically. Calendar intervals have no constant
+    width, so they fall back to the buckets seen anywhere in this response — enough to fill
+    a hole in one series when any sibling series covers that bucket.
+    """
+    step = _FIXED_INTERVAL_STEP.get(interval)
+
+    if step is None:
+        return [ts for ts in observed if first <= ts <= last]
+
+    buckets: list[datetime] = []
+    ts = first
+    while ts <= last:
+        buckets.append(ts)
+        ts += step
+
+    return buckets
+
+
+def _fill_interior_gaps(
+    grouped: dict[str, dict[str, Any]],
+    interval: Interval,
+    all_buckets: Sequence[datetime],
+) -> None:
+    """Insert explicit `(bucket, None)` points for interior buckets a series is missing.
+
+    A series that carries no row for a bucket inside its own lifetime is reporting "no data",
+    which is a different fact from "ran and generated nothing" (an explicit 0). Omitting the
+    point leaves a consumer unable to tell the two apart, or to tell either from
+    not-yet-commissioned. Only the interior is filled — nothing is invented before a unit's
+    first reading or after its last, so commissioning and retirement edges stay untouched (#615).
+    """
+    for g in grouped.values():
+        data = g["data"]
+
+        if len(data) < 2:
+            continue
+
+        expected = _expected_buckets(interval, data[0][0], data[-1][0], all_buckets)
+
+        if len(expected) == len(data):
+            continue
+
+        present = {ts for ts, _ in data}
+        data.extend((ts, None) for ts in expected if ts not in present)
+        data.sort(key=lambda x: x[0])
+
+
 def format_timeseries_response(
     network: str,
     metrics: Sequence[MetricType],
@@ -234,6 +300,8 @@ def format_timeseries_response(
         if not grouped:
             logger.warning(f"No grouped results for metric {metric_name}")
             continue
+
+        _fill_interior_gaps(grouped, interval, sorted({ts for g in grouped.values() for ts, _ in g["data"]}))
 
         # date range from actual data
         all_ts = [ts for g in grouped.values() for ts, _ in g["data"]]

--- a/opennem/schema/network.py
+++ b/opennem/schema/network.py
@@ -200,7 +200,9 @@ NetworkNEM = NetworkSchema(
     interval_size=5,
     interval_size_price=5,
     interval_shift=5,
-    data_first_seen=datetime.fromisoformat("1999-01-01T00:00:00+10:00"),
+    # first NEM unit scada interval held in facility_scada is 1998-12-07 02:40 AEST — six days
+    # before market start (1998-12-13). the data is genuine across all four mainland regions (#615)
+    data_first_seen=datetime.fromisoformat("1998-12-07T00:00:00+10:00"),
     price_first_seen=datetime.fromisoformat("2009-07-01T00:00:00+10:00"),
     interconnector_first_seen=datetime.fromisoformat("2010-01-01T00:00:00+10:00"),
     rooftop_first_seen=datetime.fromisoformat("2007-01-01T00:00:00+10:00"),
@@ -259,7 +261,7 @@ NetworkAU = NetworkSchema(
     timezone_database="AEST",
     offset=600,
     interval_size=5,
-    data_first_seen=datetime.fromisoformat("1999-01-01T00:00:00+10:00"),
+    data_first_seen=datetime.fromisoformat("1998-12-07T00:00:00+10:00"),
     subnetworks=[NetworkNEM, NetworkWEM, NetworkAEMORooftop, NetworkOpenNEMRooftopBackfill],
     fueltechs=all_fueltechs_without_rooftop,
 )

--- a/opennem/workers/facility_data_seen.py
+++ b/opennem/workers/facility_data_seen.py
@@ -41,7 +41,9 @@ def get_update_seen_query(
             max(fs.interval) as data_last_seen
         from facility_scada fs
         where
-            fs.generated > 0
+            -- any telemetered reading counts as "seen". a `> 0` filter pushed data_first_seen
+            -- late for units that started idle (MM4 by 418 days) and excluded loads entirely (#615)
+            fs.generated is not null
             and fs.is_forecast = false
             {facility_codes_query}
             {trading_interval_window}

--- a/tests/test_timeseries_interior_gaps.py
+++ b/tests/test_timeseries_interior_gaps.py
@@ -1,0 +1,82 @@
+"""Interior gap filling in the timeseries formatter (#615).
+
+A bucket a series is missing *inside* its own lifetime means "no data", which is a
+different fact from an explicit 0. These assert the point is emitted as null, and that
+nothing is invented outside a series' first and last reading.
+"""
+
+from datetime import date, datetime
+
+from opennem.api.timeseries import format_timeseries_response
+from opennem.core.grouping import PrimaryGrouping
+from opennem.core.metric import Metric
+from opennem.core.time_interval import Interval
+
+
+def _format(results, interval):
+    return format_timeseries_response(
+        network="NEM",
+        metrics=[Metric.ENERGY],
+        interval=interval,
+        primary_grouping=PrimaryGrouping.NETWORK,
+        secondary_groupings=None,
+        results=results,
+        facility_code=["ERARING"],
+    )
+
+
+def _series(response, name):
+    return next(r["data"] for r in response[0]["results"] if r["name"] == name)
+
+
+def test_missing_interior_day_returns_explicit_null():
+    """ER04 has no row for 2000-02-20 while its siblings do — the repro from #615."""
+    results = []
+    for unit, days in {"ER01": [18, 19, 20, 21, 22], "ER04": [18, 19, 21, 22]}.items():
+        results += [{"interval": date(2000, 2, d), "unit_code": unit, "energy": 100.0} for d in days]
+
+    data = _series(_format(results, Interval.DAY), "energy_ER04")
+
+    assert [v for _, v in data] == [100.0, 100.0, None, 100.0, 100.0]
+    assert data[2][0].startswith("2000-02-20")
+
+
+def test_edges_are_not_extended():
+    """A unit that starts late or retires early keeps its own bounds — no fabricated rows."""
+    results = [{"interval": date(2000, 2, d), "unit_code": "ER01", "energy": 1.0} for d in (18, 19, 20, 21, 22)]
+    results += [{"interval": date(2000, 2, d), "unit_code": "ER04", "energy": 1.0} for d in (19, 21)]
+
+    data = _series(_format(results, Interval.DAY), "energy_ER04")
+
+    assert [(ts[:10], v) for ts, v in data] == [
+        ("2000-02-19", 1.0),
+        ("2000-02-20", None),
+        ("2000-02-21", 1.0),
+    ]
+
+
+def test_five_minute_interior_gap_filled():
+    results = [{"interval": datetime(2000, 2, 20, 0, m), "unit_code": "ER01", "energy": 1.0} for m in (0, 5, 10, 15, 20)]
+    results += [{"interval": datetime(2000, 2, 20, 0, m), "unit_code": "ER04", "energy": 1.0} for m in (0, 20)]
+
+    data = _series(_format(results, Interval.INTERVAL), "energy_ER04")
+
+    assert [v for _, v in data] == [1.0, None, None, None, 1.0]
+
+
+def test_calendar_interval_fills_against_observed_buckets():
+    """1M has no constant width, so the fill uses buckets present elsewhere in the response."""
+    results = [{"interval": datetime(2000, m, 1), "unit_code": "ER01", "energy": 1.0} for m in (1, 2, 3, 4)]
+    results += [{"interval": datetime(2000, m, 1), "unit_code": "ER04", "energy": 1.0} for m in (1, 3)]
+
+    data = _series(_format(results, Interval.MONTH), "energy_ER04")
+
+    assert [(ts[:7], v) for ts, v in data] == [("2000-01", 1.0), ("2000-02", None), ("2000-03", 1.0)]
+
+
+def test_complete_series_is_untouched():
+    results = [{"interval": date(2000, 2, d), "unit_code": "ER01", "energy": 1.0} for d in (18, 19, 20)]
+
+    data = _series(_format(results, Interval.DAY), "energy_ER01")
+
+    assert [v for _, v in data] == [1.0, 1.0, 1.0]

--- a/tests/test_timeseries_interior_gaps.py
+++ b/tests/test_timeseries_interior_gaps.py
@@ -64,14 +64,41 @@ def test_five_minute_interior_gap_filled():
     assert [v for _, v in data] == [1.0, None, None, None, 1.0]
 
 
-def test_calendar_interval_fills_against_observed_buckets():
-    """1M has no constant width, so the fill uses buckets present elsewhere in the response."""
-    results = [{"interval": datetime(2000, m, 1), "unit_code": "ER01", "energy": 1.0} for m in (1, 2, 3, 4)]
-    results += [{"interval": datetime(2000, m, 1), "unit_code": "ER04", "energy": 1.0} for m in (1, 3)]
+def test_calendar_interval_steps_by_months():
+    """1M has no constant width — buckets step a whole month at a time, across a year boundary."""
+    results = [{"interval": datetime(1999, 11, 1), "unit_code": "ER04", "energy": 1.0}]
+    results += [{"interval": datetime(2000, 2, 1), "unit_code": "ER04", "energy": 2.0}]
+
+    data = _series(_format(results, Interval.MONTH), "energy_ER04")
+
+    assert [(ts[:7], v) for ts, v in data] == [
+        ("1999-11", 1.0),
+        ("1999-12", None),
+        ("2000-01", None),
+        ("2000-02", 2.0),
+    ]
+
+
+def test_calendar_gap_filled_for_a_lone_series():
+    """The only series in the response still gets its hole filled (no sibling to borrow from)."""
+    results = [{"interval": datetime(2000, m, 1), "unit_code": "ER04", "energy": 1.0} for m in (1, 3)]
 
     data = _series(_format(results, Interval.MONTH), "energy_ER04")
 
     assert [(ts[:7], v) for ts, v in data] == [("2000-01", 1.0), ("2000-02", None), ("2000-03", 1.0)]
+
+
+def test_quarterly_steps_by_three_months():
+    results = [{"interval": datetime(2000, m, 1), "unit_code": "ER04", "energy": 1.0} for m in (1, 10)]
+
+    data = _series(_format(results, Interval.QUARTER), "energy_ER04")
+
+    assert [(ts[:7], v) for ts, v in data] == [
+        ("2000-01", 1.0),
+        ("2000-04", None),
+        ("2000-07", None),
+        ("2000-10", 1.0),
+    ]
 
 
 def test_complete_series_is_untouched():


### PR DESCRIPTION
addresses #615.

## what the investigation found

the reported 8.5% of absent coal unit-days in 1999-2000 are **not lost data**. of 3,056 gaps over 1h in prod \`facility_scada\`, 2,482 begin with the unit already under 10 MW and resume ramping from near zero. the reporter's own ER04 example is a shutdown: ramps 244 -> 95 -> 82 MW, last row 1.0 MW at 2000-02-19 09:25, nothing, then 33 MW at 2000-02-21 04:05 with a startup ramp. PLAYFB1 has 4.2% of 1999's intervals because playford b was a seasonal peaker. the fueltech gradient in the issue tracks capacity factor, and the sunday skew is sunday minimum demand.

re-ingest is also not possible: the nemweb MMSDM archive begins 2009.

so the fixes here are the parts that are real.

## changes

- **`data_first_seen` 1999-01-01 -> 1998-12-07** for NetworkNEM and NetworkAU. `facility_scada` holds genuine nem data from 1998-12-07 02:40 (706k rows, 134 duids, all four mainland regions, continuous across the 1998-12-13 market start). the old value bounded the clickhouse backfill, so it was never aggregated and the api clipped at 1999-01-01.
- **explicit nulls for interior gaps** in the timeseries formatter. a bucket a series misses inside its own first/last reading now emits `[ts, null]` instead of being omitted, so "no data" is distinguishable from an explicit `0`. edges are never extended, so commissioning and retirement bounds are untouched. fixed-width intervals step arithmetically; calendar intervals step by whole months.
- **`facility_data_seen`: `generated > 0` -> `generated is not null`**. the filter pushed `data_first_seen` late for units that started idle - MM4 by 418 days - and excluded loads entirely.

## data run

both dev and prod:
- clickhouse `unit_intervals` backfilled for 1998-12-07 -> 12-31 (670,365 rows, ~400-500 GWh/day, matching 1998 nem levels). all downstream MVs auto-populated at 100% completeness.
- `market_summary` backfilled from 1998-12-13 01:30, the actual market start and the first `balancing_summary` row. verified plausible: nsw 7.2 GW / \$23, vic 3.7 GW, qld 4.0 GW, sa 1.2 GW.
- `units.data_first_seen` / `data_last_seen` recomputed.

## still open on #615, tracked separately

the spring-forward hour (02:00-02:59) is entirely absent market-wide on all ten changeover sundays 1999-2008, including 2000-08-27 when dst started early for the olympics. same family as the 2009-2023 dst repair, but unfixable from MMSDM.