### PR TITLE
feat(monitors): alert on facility_scada codes dropped at clickhouse ingest

### DIFF
--- a/opennem/monitors/unmapped_codes.py
+++ b/opennem/monitors/unmapped_codes.py
@@ -1,0 +1,206 @@
+"""Detect facility_scada codes whose energy is silently dropped on the way to ClickHouse.
+
+`aggregates/unit_intervals.py` builds its source rows with
+
+    FROM facility_scada fs
+    JOIN units u        ON fs.facility_code = u.code
+    JOIN facilities f   ON u.station_id = f.id
+    JOIN fueltech ft    ON ft.code = u.fueltech_id
+
+Every one of those is an inner join, so a code that fails any of them contributes
+nothing to ClickHouse and no warning is raised. Because both the API and the static
+exports read from ClickHouse, the loss is invisible downstream — this is how ~19,900 GWh
+of WEM history (2006-2016) stayed hidden until #599.
+
+Two distinct failure modes are checked:
+
+1. **unmapped** — a `facility_scada` code with no `units` row at all.
+2. **unjoinable** — a `units` row that exists but has no `fueltech_id` or no
+   `station_id`, so it dies on the second or third join instead of the first.
+
+The check is windowed rather than full-history. A rolling window answers the question
+that actually matters — "is AEMO sending us something we are dropping *right now*" —
+and it does so in seconds against a table where the full-history equivalent takes
+upwards of fifteen minutes. It also keeps the allowlist small: historic unmapped codes
+age out of the window on their own instead of needing to be enumerated forever.
+"""
+
+import logging
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from sqlalchemy import text
+
+from opennem.clients.slack import slack_message
+from opennem.db import get_read_session
+
+logger = logging.getLogger("opennem.monitors.unmapped_codes")
+
+# Codes deliberately left unmapped that still carry energy. Keep this as short as
+# possible — anything here is data we are knowingly discarding.
+KNOWN_UNMAPPED_CODES: set[str] = {
+    # bouldercombe + dalrymple historic DUIDs. Mapping them as units would double count
+    # against the derived gen/load series that covers the same period — see #603.
+    "BBATTERY",
+    "BBATRYL1",
+    "DALNTH01",
+}
+
+# Interconnectors have no fueltech by design and are excluded from the generation
+# aggregate; their flows are handled by the flows pipeline instead.
+INTERCONNECTOR_PATTERNS = ("MNSP", "FLOW", "-NSW1", "-QLD1", "-VIC1", "-SA1", "-TAS1", "V-S", "V-SA", "N-Q")
+
+# MWh over the window. Above float noise, far below anything a real generator produces.
+ENERGY_THRESHOLD_MWH = 1.0
+
+DEFAULT_WINDOW_DAYS = 7
+
+
+@dataclass(frozen=True, slots=True)
+class DroppedCode:
+    """A code whose energy never reaches ClickHouse."""
+
+    network_id: str
+    code: str
+    reason: str
+    energy_mwh: float
+    intervals: int
+
+    def __str__(self) -> str:
+        return f"{self.network_id} {self.code} ({self.reason}): {self.energy_mwh:,.1f} MWh over {self.intervals:,} intervals"
+
+
+REASON_NO_UNIT = "no units row"
+REASON_NO_FUELTECH = "unit has no fueltech or station"
+
+
+def _is_interconnector(code: str) -> bool:
+    return any(pattern in code for pattern in INTERCONNECTOR_PATTERNS)
+
+
+def filter_dropped(rows: Iterable[Sequence[Any]], reason: str) -> list[DroppedCode]:
+    """Turn query rows into alertable findings, dropping the ones we expect.
+
+    Rows are `(network_id, code, energy, intervals)` — either plain tuples or SQLAlchemy
+    `Row`s. Interconnectors are excluded because they carry no fueltech by design and
+    never enter the generation aggregate.
+    """
+    findings: list[DroppedCode] = []
+
+    for network_id, code, energy, intervals in rows:
+        if code in KNOWN_UNMAPPED_CODES or _is_interconnector(code):
+            logger.debug(f"Skipping expected unmapped code {code}")
+            continue
+
+        findings.append(
+            DroppedCode(
+                network_id=network_id,
+                code=code,
+                reason=reason,
+                energy_mwh=float(energy),
+                intervals=intervals,
+            )
+        )
+
+    return findings
+
+
+_UNMAPPED_QUERY = text("""
+    select
+        fs.network_id,
+        fs.facility_code as code,
+        coalesce(sum(fs.energy), 0) as energy,
+        count(*) as intervals
+    from facility_scada fs
+    left join units u on fs.facility_code = u.code
+    where
+        u.code is null
+        and fs.is_forecast is false
+        and fs.interval >= now() - (:window_days * interval '1 day')
+    group by 1, 2
+    having abs(coalesce(sum(fs.energy), 0)) > :threshold
+""")
+
+_UNJOINABLE_QUERY = text("""
+    select
+        fs.network_id,
+        u.code as code,
+        coalesce(sum(fs.energy), 0) as energy,
+        count(*) as intervals
+    from units u
+    join facility_scada fs on fs.facility_code = u.code
+    where
+        (u.fueltech_id is null or u.station_id is null)
+        and fs.is_forecast is false
+        and fs.interval >= now() - (:window_days * interval '1 day')
+    group by 1, 2
+    having abs(coalesce(sum(fs.energy), 0)) > :threshold
+""")
+
+
+async def check_unmapped_facility_codes(window_days: int = DEFAULT_WINDOW_DAYS) -> list[DroppedCode]:
+    """Find codes carrying energy that the ClickHouse ingest joins discard.
+
+    Args:
+        window_days: how far back to look. Keep this comfortably longer than the
+            longest crawler lag (WEM publishes ~24h behind) so a newly introduced
+            code is seen before it ages out.
+
+    Returns:
+        Codes to alert on, worst first. Empty when the pipeline is clean.
+    """
+    params = {"window_days": window_days, "threshold": ENERGY_THRESHOLD_MWH}
+
+    async with get_read_session() as session:
+        unmapped = (await session.execute(_UNMAPPED_QUERY, params)).all()
+        unjoinable = (await session.execute(_UNJOINABLE_QUERY, params)).all()
+
+    dropped = filter_dropped(unmapped, REASON_NO_UNIT) + filter_dropped(unjoinable, REASON_NO_FUELTECH)
+    dropped.sort(key=lambda d: abs(d.energy_mwh), reverse=True)
+
+    if dropped:
+        logger.warning(f"{len(dropped)} facility_scada codes are being dropped at clickhouse ingest over {window_days}d")
+        for entry in dropped:
+            logger.warning(f"  {entry}")
+    else:
+        logger.info(f"No dropped facility_scada codes over the last {window_days} days")
+
+    return dropped
+
+
+async def run_unmapped_code_check(window_days: int = DEFAULT_WINDOW_DAYS) -> list[DroppedCode]:
+    """Run the check and alert to Slack when anything is being dropped."""
+    from opennem import settings
+
+    dropped = await check_unmapped_facility_codes(window_days=window_days)
+
+    if not dropped:
+        return dropped
+
+    lines = "\n".join(f"• {entry}" for entry in dropped)
+    await slack_message(
+        webhook_url=settings.slack_hook_monitoring,
+        message=(
+            f"*Unmapped facility codes dropping energy* ({window_days}d window)\n"
+            f"These codes carry energy in `facility_scada` but are discarded by the clickhouse "
+            f"ingest joins, so they are missing from the API and every export:\n{lines}\n"
+            f"Map them in the CMS, or add to `KNOWN_UNMAPPED_CODES` if the omission is intentional."
+        ),
+        tag_users=settings.slack_admin_alert,
+    )
+
+    return dropped
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    async def _main() -> None:
+        dropped = await check_unmapped_facility_codes()
+        if not dropped:
+            print("clean — nothing being dropped")
+        for entry in dropped:
+            print(entry)
+
+    asyncio.run(_main())

--- a/opennem/tasks/app.py
+++ b/opennem/tasks/app.py
@@ -39,6 +39,7 @@ from opennem.tasks.tasks import (
     task_catchup_aggregates,
     task_catchup_check,
     task_catchup_days,
+    task_check_unmapped_facility_codes,
     task_check_unsplit_batteries,
     task_clean_tmp_dir,
     task_export_capacity_history,
@@ -328,6 +329,15 @@ class WorkerSettings:
             minute=45,
             second=0,
             timeout=600,
+            unique=True,
+        ),
+        # Check for facility_scada codes the clickhouse ingest is silently dropping
+        cron(
+            task_check_unmapped_facility_codes,
+            hour=10,
+            minute=15,
+            second=0,
+            timeout=None,
             unique=True,
         ),
         # Check for unsplit batteries

--- a/opennem/tasks/tasks.py
+++ b/opennem/tasks/tasks.py
@@ -34,6 +34,7 @@ from opennem.db.clickhouse.schema import optimize_clickhouse_tables
 from opennem.exporter.facilities import export_facilities_static
 
 # from opennem.exporter.historic import export_historic_intervals
+from opennem.monitors.unmapped_codes import run_unmapped_code_check
 from opennem.pipelines.export import run_export_power_latest_for_network
 from opennem.schema.network import NetworkAU, NetworkNEM, NetworkWEM
 from opennem.utils.dates import get_last_completed_interval_for_network, get_today_opennem
@@ -331,6 +332,22 @@ async def task_check_unsplit_batteries(ctx: dict) -> None:
         await check_unsplit_batteries()
     except Exception as e:
         logger.error(f"Error checking unsplit batteries: {str(e)}")
+        raise
+
+
+async def task_check_unmapped_facility_codes(ctx: dict) -> None:
+    """Task to check for facility_scada codes whose energy the clickhouse ingest silently drops.
+
+    Runs daily and alerts via Slack. A new code appearing here means AEMO introduced or
+    renamed a DUID and we are dropping live data from every downstream metric (#604).
+
+    Args:
+        ctx (dict): Task context
+    """
+    try:
+        await run_unmapped_code_check()
+    except Exception as e:
+        logger.error(f"Error checking unmapped facility codes: {str(e)}")
         raise
 
 

--- a/tests/test_unmapped_codes.py
+++ b/tests/test_unmapped_codes.py
@@ -1,0 +1,57 @@
+"""Filtering logic for the dropped-facility-code monitor (#604)."""
+
+from opennem.monitors.unmapped_codes import (
+    REASON_NO_FUELTECH,
+    REASON_NO_UNIT,
+    DroppedCode,
+    filter_dropped,
+)
+
+
+def test_unmapped_code_with_energy_is_reported():
+    rows = [("WEM", "NEWCODE1", 1234.5, 288)]
+
+    findings = filter_dropped(rows, REASON_NO_UNIT)
+
+    assert findings == [DroppedCode(network_id="WEM", code="NEWCODE1", reason=REASON_NO_UNIT, energy_mwh=1234.5, intervals=288)]
+
+
+def test_known_unmapped_codes_are_skipped():
+    """bouldercombe/dalrymple are deliberately unmapped — see #603."""
+    rows = [("NEM", "BBATTERY", 900.0, 288), ("NEM", "DALNTH01", 400.0, 288)]
+
+    assert filter_dropped(rows, REASON_NO_UNIT) == []
+
+
+def test_interconnectors_are_skipped():
+    """No fueltech by design; flows are handled by a separate pipeline."""
+    rows = [
+        ("NEM", "VIC1-NSW1", 80920.0, 2131),
+        ("NEM", "N-Q-MNSP1", -2855.0, 2131),
+        ("NEM", "V-SA", -23644.0, 2131),
+        ("NEM", "T-V-MNSP1", 8921.0, 2131),
+    ]
+
+    assert filter_dropped(rows, REASON_NO_FUELTECH) == []
+
+
+def test_negative_energy_still_reported():
+    """A dropped load is as much a hole in the data as a dropped generator."""
+    rows = [("WEM", "SOMELOAD1", -5000.0, 288)]
+
+    findings = filter_dropped(rows, REASON_NO_UNIT)
+
+    assert len(findings) == 1
+    assert findings[0].energy_mwh == -5000.0
+
+
+def test_reason_is_carried_through():
+    rows = [("NEM", "ORPHAN1", 10.0, 12)]
+
+    assert filter_dropped(rows, REASON_NO_FUELTECH)[0].reason == REASON_NO_FUELTECH
+
+
+def test_str_is_readable_for_slack():
+    entry = DroppedCode(network_id="WEM", code="NEWCODE1", reason=REASON_NO_UNIT, energy_mwh=19900.456, intervals=12345)
+
+    assert str(entry) == "WEM NEWCODE1 (no units row): 19,900.5 MWh over 12,345 intervals"


### PR DESCRIPTION
closes #604.

## the hole

`aggregates/unit_intervals.py` builds its source rows with three inner joins:

```sql
FROM facility_scada fs
JOIN units u      ON fs.facility_code = u.code
JOIN facilities f ON u.station_id = f.id
JOIN fueltech ft  ON ft.code = u.fueltech_id
```

a code failing any of them contributes nothing to clickhouse, with no warning and no count. both the api and the static exports read from clickhouse, so the loss is invisible in every downstream metric. that is how ~19,900 GWh of wem history stayed hidden until #599.

## what the check does

two failure modes, not one:

1. **no units row** — the case in the issue.
2. **unit exists but has no `fueltech_id` or `station_id`** — dies on the second or third join instead of the first. the issue's proposed query misses this entirely. there are currently 21 such units.

## windowed, not full-history

the issue proposed a full-history query. i went with a rolling 7-day window instead:

- **2.4s against prod, vs 15+ minutes** for the full-history equivalent on a table this size. that is the difference between something that can run daily and something that can't.
- it answers the question that actually matters, which the issue itself identifies — "the important signal is a NEW code showing up with real energy".
- historic unmapped codes age out of the window by themselves, so the allowlist stays short instead of accumulating every code ever seen. the issue's proposed allowlist had ~8 entries and would only have grown; `KNOWN_UNMAPPED_CODES` currently has 3 (the bouldercombe/dalrymple duids from #603).

interconnectors are excluded by pattern — they carry no fueltech by design and are handled by the flows pipeline.

## verification

against prod:

```
No dropped facility_scada codes over the last 7 days
clean — nothing being dropped
```

positive control with the threshold dropped to -1 catches 212 codes (the demand-side-programme codes that legitimately report 0 MWh), confirming both queries fire and the interconnector/allowlist filtering works.

6 unit tests over the filter logic. runs daily at 10:15, alerts to the monitoring channel tagging admins.