### PR TITLE
fix(nem): alias retired bouldercombe/dalrymple duids onto their paired codes

### DIFF
--- a/opennem/controllers/nem.py
+++ b/opennem/controllers/nem.py
@@ -12,7 +12,7 @@ import pandas as pd
 from sqlalchemy.dialects.postgresql import insert
 
 from opennem.controllers.schema import ControllerReturn
-from opennem.core.battery import get_battery_unit_map
+from opennem.core.battery import HISTORIC_UNIT_ALIASES, get_battery_unit_map
 from opennem.core.networks import NetworkNEM
 from opennem.core.normalizers import clean_float
 from opennem.core.parsers.aemo.mms import AEMOTableSchema, AEMOTableSet
@@ -135,6 +135,21 @@ async def generate_facility_scada(
 
     # Drop the battery_copy field
     df = df.drop(columns=["battery_copy"])
+
+    # Retired single-direction duids are carried forward under the paired gen/load codes
+    # we model as units. Emit a copy rather than renaming, so the original aemo code stays
+    # in facility_scada and a re-crawl of pre-2026-02 data heals the derived series (#603).
+    def is_alias_unit(row) -> bool:
+        return row["facility_code"] in HISTORIC_UNIT_ALIASES
+
+    def map_alias_code(row) -> str:
+        return HISTORIC_UNIT_ALIASES[row["facility_code"]]
+
+    alias_copies = df.loc[df.apply(is_alias_unit, axis=1)].copy()
+
+    if len(alias_copies) > 0:
+        alias_copies["facility_code"] = alias_copies.apply(map_alias_code, axis=1)
+        df = pd.concat([df, alias_copies], ignore_index=True)
 
     # fill in energies
     df["energy"] = df.generated / (60 / network.interval_size)

--- a/opennem/core/battery.py
+++ b/opennem/core/battery.py
@@ -31,6 +31,22 @@ class BatteryUnitMap(BaseModel):
 UNIT_MAP: dict[DUIDType, BatteryUnitMap] = {}
 
 
+# Historic single-direction DUIDs that AEMO retired in favour of the paired
+# generation/load codes we already model as units.
+#
+# These are NOT bidirectional and must never be sign-split: each one carries a single
+# direction, and its replacement code holds byte-identical values for every interval of
+# the overlap (verified 2025-06-01→06-08: BBATTERY==BBATTERYG1 and BBATRYL1==BBATTERYL1
+# on all 2,016 intervals; DALNTH01==DALNTHG1 on all 738). Splitting them by sign would
+# route the small negative auxiliary draw on the generation code into the charge unit,
+# double counting against the real charge DUID. So they are aliased 1:1 instead (#603).
+HISTORIC_UNIT_ALIASES: dict[str, str] = {
+    "BBATTERY": "BBATTERYG1",  # bouldercombe discharge
+    "BBATRYL1": "BBATTERYL1",  # bouldercombe charge
+    "DALNTH01": "DALNTHG1",  # dalrymple north discharge
+}
+
+
 async def get_battery_unit_map() -> dict[str, BatteryUnitMap]:
     """Get the battery unit mapping, generating it if not already cached.
 
@@ -57,7 +73,9 @@ def _generate_manual_battery_unit_map() -> dict[str, BatteryUnitMap]:
         "TEMPB1": BatteryUnitMap(unit="TEMPB1", charge_unit="TEMPBL1", discharge_unit="TEMPBG1"),  # templers
         "WDBESS1": BatteryUnitMap(unit="WDBESS1", charge_unit="WDBESSL1", discharge_unit="WDBESSG1"),  # western downs
         "DALNTH1": BatteryUnitMap(unit="DALNTH1", charge_unit="DALNTHL1", discharge_unit="DALNTHG1"),  # dairymple north
-        "DALNTH01": BatteryUnitMap(unit="DALNTH01", charge_unit="DALNTHL1", discharge_unit="DALNTHG1"),  # dairymple north
+        # DALNTH01 is the historic gen-only duid, not a bidirectional unit — see
+        # HISTORIC_UNIT_ALIASES. Sign-splitting it here was a no-op only because it never
+        # goes negative; BBATTERY does, which is why both are aliased instead (#603).
         "BBATTERY1": BatteryUnitMap(unit="BBATTERY1", charge_unit="BBATTERYL1", discharge_unit="BBATTERYG1"),  # battery
         # station code based?
         "0COLLIE_ESR2": BatteryUnitMap(unit="COLLIE_BESS2", charge_unit="COLLIE_BESSL2", discharge_unit="COLLIE_BESSG2"),
@@ -68,7 +86,9 @@ def _generate_manual_battery_unit_map() -> dict[str, BatteryUnitMap]:
         "0TEMPLERBESS": BatteryUnitMap(unit="TEMPB1", charge_unit="TEMPBL1", discharge_unit="TEMPBG1"),  # templers
         "WDBESS": BatteryUnitMap(unit="WDBESS1", charge_unit="WDBESSL1", discharge_unit="WDBESSG1"),  # western downs
         "DALNTH": BatteryUnitMap(unit="DALNTH", charge_unit="DALNTHL1", discharge_unit="DALNTHG1"),  # dairymple north
-        "BBATTERY": BatteryUnitMap(unit="BBATTERY1", charge_unit="BBATTERYL1", discharge_unit="BBATTERYG1"),  # battery
+        # NOTE: no "BBATTERY" entry. It reads as a station code here but collides with the
+        # historic duid of the same name, and `is_battery_unit()` matches on duid — so it
+        # sign-split real bouldercombe generation. Aliased in HISTORIC_UNIT_ALIASES (#603).
     }
 
 

--- a/tests/test_historic_unit_aliases.py
+++ b/tests/test_historic_unit_aliases.py
@@ -1,0 +1,46 @@
+"""Historic single-direction DUID aliasing (#603).
+
+The retired bouldercombe/dalrymple duids carry a single direction each and must be
+aliased 1:1 onto the paired gen/load codes — never sign-split, which would route the
+generation code's small negative auxiliary draw into the charge unit and double count
+against the real charge duid.
+"""
+
+from opennem.core.battery import HISTORIC_UNIT_ALIASES, _generate_manual_battery_unit_map
+
+
+def test_historic_duids_map_to_the_paired_codes():
+    assert HISTORIC_UNIT_ALIASES == {
+        "BBATTERY": "BBATTERYG1",
+        "BBATRYL1": "BBATTERYL1",
+        "DALNTH01": "DALNTHG1",
+    }
+
+
+def test_aliased_duids_are_not_also_sign_split():
+    """The two maps must stay disjoint.
+
+    `is_battery_unit()` matches on duid, so a code in both maps would be sign-split *and*
+    aliased, producing double-counted charge rows. "BBATTERY" was in the battery map as a
+    station code and collided with the duid of the same name.
+    """
+    battery_map = _generate_manual_battery_unit_map()
+
+    overlap = set(HISTORIC_UNIT_ALIASES) & set(battery_map)
+
+    assert not overlap, f"codes are both aliased and sign-split: {sorted(overlap)}"
+
+
+def test_bidirectional_units_are_still_sign_split():
+    """The real bidirectional duids must keep their split — only the historic ones moved."""
+    battery_map = _generate_manual_battery_unit_map()
+
+    assert battery_map["BBATTERY1"].charge_unit == "BBATTERYL1"
+    assert battery_map["BBATTERY1"].discharge_unit == "BBATTERYG1"
+    assert battery_map["DALNTH1"].charge_unit == "DALNTHL1"
+    assert battery_map["DALNTH1"].discharge_unit == "DALNTHG1"
+
+
+def test_alias_targets_are_never_themselves_aliased():
+    """No chaining — an alias target must be a terminal code."""
+    assert not set(HISTORIC_UNIT_ALIASES.values()) & set(HISTORIC_UNIT_ALIASES)


### PR DESCRIPTION
part of #603. code half; the data backfill is run separately.

## what the investigation found

the issue's framing turned out to be off in three ways.

**1. the stated pre-derived gap is ~10x smaller than estimated.** measured on prod:

| window | issue estimate | actual |
|---|---|---|
| BBATTERY gen, 2023-07-11 → 09-30 | ~40 GWh | **1.42 GWh** |
| BBATRYL1 load, 2023-07-11 → 11-02 | — | **1.73 GWh** |
| DALNTH01 gen, 2018-06-04 → 09-30 | ~4.7 GWh | **0.17 GWh** |

**2. the real hole is a 10-month void in the derived series**, 2023-12 → 2024-09, ~28 GWh of bouldercombe generation with no derived counterpart. the reason: the bidirectional duid the split derives from doesn't exist yet. `BBATTERY1` starts **2024-10-04** and `DALNTH1` starts **2024-08-08** — not 2026-02-09, which is when the *historic* duids stop.

**3. clickhouse was missing all of 2024** for all three derived codes despite postgres holding the rows — 17.6 GWh absent from the api and every export. across the whole database these are the only battery units with 2023 data and no 2024 data.

## the model: 1:1 alias, not a sign split

the decisive evidence is interval-level rather than monthly sums. over a sample overlap week:

```
BBATTERY1  (bidirectional)  2016 intervals, 1063 negative
BBATTERY   (hist gen)        953 intervals, all >= 0   identical to BBATTERYG1
BBATRYL1   (hist load)      1063 intervals, all >= 0   identical to BBATTERYL1
```

953 + 1063 = 2016. zero differing intervals. the derived pair is a straight rename of the historic duids, so that is how this models it.

the alias emits a **copy**, not a rename — the original aemo code stays in `facility_scada`, and a re-crawl of pre-2026-02 data now heals the derived series instead of leaving a hole.

## a landmine removed

`"BBATTERY"` sat in the sign-split map as a station code, but `is_battery_unit()` matches on **duid** and there is a historic duid of the same name. any re-crawl of pre-2026-02 nem data would have sign-split real bouldercombe generation, routing the gen code's small negative auxiliary draw into the charge unit and double counting against `BBATRYL1`. removed, with a test asserting the two maps stay disjoint so it cannot come back.

## known artifact

before 2024-10 the `BBATTERY` duid carried small negative excursions — about -0.14 GWh/month against +2.5 GWh of discharge. that is auxiliary draw, not charging: the real charge series `BBATRYL1` runs ~3.0 GWh over the same month, a plausible 85% round trip against the discharge. aliasing straight through preserves those negatives, so `BBATTERYG1` shows occasional small negatives pre-2024-10 where it never does after. this is the metered reality rather than a smoothed series; clamping to zero is a one-line change if we would rather the discharge series never go negative.

4 tests. verified on dev before prod.