### PR TITLE
fix(api): honour the month param on v3 power network region by fueltech

### DIFF
--- a/opennem/api/stats/router.py
+++ b/opennem/api/stats/router.py
@@ -543,6 +543,12 @@ async def power_network_region_fueltech(
     # redirect to static JSONs
     redirect_url_format = "https://data.opennem.org.au/v3/stats/au/{network_code_out}/{network_region_out}power/7d.json"
 
+    # The static json this redirects to only ever holds the last 7 days, so it can only
+    # answer a request that didn't ask for a specific month. Capture that before `month`
+    # is defaulted below, otherwise every request looks like a current one and historical
+    # queries are silently served 7 days of recent data instead (#393).
+    month_requested = month is not None
+
     if not month:
         month = get_today_nem().date()
 
@@ -566,7 +572,7 @@ async def power_network_region_fueltech(
         network_region_out=network_region_out,
     )
 
-    if settings.redirect_api_static:
+    if settings.redirect_api_static and not month_requested:
         return RedirectResponse(url=redirect_to, status_code=status.HTTP_302_FOUND)
 
     interval_obj = network.get_interval()


### PR DESCRIPTION
closes #393. the diagnosis and approach are @ekemini-e's from #392, which was closed unmerged in september — crediting it here.

## the bug

`month` is defaulted to today at the top of the handler, *before* the static-redirect check:

```python
if not month:
    month = get_today_nem().date()
...
if settings.redirect_api_static:
    return RedirectResponse(url=".../power/7d.json")
```

so by the time the redirect is evaluated every request looks like a current one, the redirect always fires, and the caller gets the last 7 days from `7d.json` no matter which month they asked for. `redirect_api_static` is enabled in prod, so this is what everyone hits.

## the fix

capture whether a month was actually requested before defaulting, and only redirect when it wasn't:

```python
month_requested = month is not None
...
if settings.redirect_api_static and not month_requested:
```

three lines. checked the rest of the codebase — this is the only use of `redirect_api_static`, so there's no sibling endpoint with the same shape.

## why bother with a deprecated endpoint

the router is hidden (`include_in_schema=False`) and superseded by v4, but it is still mounted and still returning wrong data to anyone calling it. a documented parameter that silently returns something else is worse than one that errors. this doesn't commit us to a v3 sunset story either way.