### PR TITLE
fix(aggregates): rebuild completeness-versioned daily views after a backlog run

### DIFF
--- a/opennem/aggregates/unit_intervals.py
+++ b/opennem/aggregates/unit_intervals.py
@@ -12,10 +12,14 @@ import resource
 import sys
 from collections.abc import AsyncIterator, Sequence
 from datetime import datetime, timedelta
+from typing import TYPE_CHECKING
 
 import polars as pl
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
+
+if TYPE_CHECKING:
+    from opennem.db.clickhouse.materialized_views import MaterializedView
 
 from opennem.db import get_write_session
 from opennem.db.clickhouse import (
@@ -695,6 +699,7 @@ async def process_unit_intervals_backlog(
     end_date: datetime,
     chunk_size: timedelta = timedelta(days=3),
     network: NetworkSchema | None = None,
+    rebuild_daily_views: bool = True,
 ) -> None:
     """
     Process historical unit interval data in chunks.
@@ -704,6 +709,10 @@ async def process_unit_intervals_backlog(
         start_date: Start date for processing
         end_date: End date for processing
         chunk_size: Size of each processing chunk
+        rebuild_daily_views: Rebuild the fueltech/renewable daily views over the same window
+            once the data is in. Required for correctness on any historical window — see
+            `_rebuild_daily_views`. Pass False only on hot paths that re-run a recent window
+            every few minutes, where the rebuild cost would dwarf the write.
     """
     current_start = start_date
     # Schema-ensure and inserts hit the blocking sync CH driver. This runs while `session`
@@ -741,6 +750,44 @@ async def process_unit_intervals_backlog(
             logger.warning(f"No records found for {current_start} to {chunk_end}")
 
         current_start = chunk_end
+
+    if rebuild_daily_views:
+        await _rebuild_daily_views(start_date=start_date, end_date=end_date)
+
+
+# The fueltech/renewable daily views are keyed by (date, network, region, fueltech), so a
+# late write for a day they already hold produces a competing version of an existing row.
+# Their version encodes completeness (interval_count * 1e9 + max(version)) — deliberately,
+# so a partial auto-populate can't clobber a full backfill — which means the late row,
+# covering only what was just written, loses and is discarded. The daily aggregate then
+# keeps its pre-backfill value indefinitely while unit_intervals moves on.
+#
+# unit_intervals_daily_mv is not affected: it's keyed per unit, so a backfilled unit is a
+# new key rather than a competing version. That asymmetry is what surfaced as network
+# totals disagreeing with the sum of their units (#592).
+_DAILY_VIEWS_NEEDING_REBUILD: "list[MaterializedView | str]" = [
+    "fueltech_intervals_daily_mv",
+    "renewable_intervals_daily_mv",
+]
+
+
+async def _rebuild_daily_views(start_date: datetime, end_date: datetime) -> None:
+    """Rebuild the completeness-versioned daily views over a window just written to.
+
+    DELETE-then-INSERT replaces the rows outright instead of trying to out-version them.
+    """
+    from opennem.db.clickhouse.materialized_views import backfill_materialized_views
+
+    logger.info(f"Rebuilding daily views from {start_date} to {end_date}")
+
+    # Blocking sync CH driver — keep it off the event loop (#572).
+    await asyncio.to_thread(
+        backfill_materialized_views,
+        views=_DAILY_VIEWS_NEEDING_REBUILD,
+        start_date=start_date,
+        end_date=end_date,
+        refresh_views=False,
+    )
 
 
 async def process_unit_intervals_backlog_streaming(
@@ -966,6 +1013,8 @@ async def run_unit_intervals_backlog(start_date: datetime | None = None, network
             network=network,
         )
         logger.info(f"Backlog processing complete: {total_processed} total records processed")
+
+    await _rebuild_daily_views(start_date=start_date, end_date=end_date)
 
     # Verify the data was inserted
     result = client.execute(

--- a/opennem/tasks/tasks.py
+++ b/opennem/tasks/tasks.py
@@ -125,6 +125,9 @@ async def task_wem_day_crawl(ctx) -> None:
             start_date=start_date,
             end_date=end_date,
             network=NetworkWEM,
+            # runs every few minutes over a recent window — the daily views are rebuilt by
+            # the catchup pass instead, which covers the same days once per day (#592)
+            rebuild_daily_views=False,
         )
 
     await run_export_power_latest_for_network(network=NetworkWEM)
@@ -148,6 +151,9 @@ async def task_wem_interval_check(ctx) -> None:
             start_date=start_date,
             end_date=end_date,
             network=NetworkWEM,
+            # runs every few minutes over a recent window — the daily views are rebuilt by
+            # the catchup pass instead, which covers the same days once per day (#592)
+            rebuild_daily_views=False,
         )
 
     await run_export_power_latest_for_network(network=NetworkWEM)

--- a/opennem/workers/catchup.py
+++ b/opennem/workers/catchup.py
@@ -368,7 +368,8 @@ async def catchup_date(target_date: datetime) -> None:
     # aggregates
     logger.info(f"Catchup for {day_start.date()}: aggregating")
     async with get_read_session() as session:
-        await process_unit_intervals_backlog(session=session, start_date=day_start, end_date=day_end)
+        # catchup already rebuilds every daily view below, so skip the targeted rebuild
+        await process_unit_intervals_backlog(session=session, start_date=day_start, end_date=day_end, rebuild_daily_views=False)
     async with get_read_session() as session:
         await process_market_summary_backlog(session=session, start_date=day_start, end_date=day_end)
 

--- a/tests/test_daily_view_rebuild.py
+++ b/tests/test_daily_view_rebuild.py
@@ -1,0 +1,48 @@
+"""Daily view rebuild after a historical backlog run (#592).
+
+The fueltech/renewable daily views version rows by completeness, so a write landing on a
+day they already hold loses the comparison and is discarded. Any backlog run therefore has
+to rebuild them for the same window — except on the few-minute hot paths, where the rebuild
+would cost far more than the write and the daily catchup covers the same days anyway.
+"""
+
+import inspect
+
+from opennem.aggregates import unit_intervals
+
+
+def test_rebuild_is_the_default():
+    """A caller who doesn't think about it must get the safe behaviour."""
+    sig = inspect.signature(unit_intervals.process_unit_intervals_backlog)
+
+    assert sig.parameters["rebuild_daily_views"].default is True
+
+
+def test_only_the_completeness_versioned_views_are_rebuilt():
+    """unit_intervals_daily_mv is keyed per unit so it can't go stale — rebuilding it would
+    be wasted work on every backlog run."""
+    assert unit_intervals._DAILY_VIEWS_NEEDING_REBUILD == [
+        "fueltech_intervals_daily_mv",
+        "renewable_intervals_daily_mv",
+    ]
+
+
+def test_hot_paths_opt_out():
+    """The 5-minute WEM tasks must not trigger a rebuild on every run."""
+    source = inspect.getsource(unit_intervals)  # noqa: F841  (kept for symmetry / debugging)
+
+    from opennem.tasks import tasks
+
+    task_source = inspect.getsource(tasks)
+    wem_calls = task_source.count("rebuild_daily_views=False")
+
+    assert wem_calls == 2, f"expected both WEM interval tasks to opt out, found {wem_calls}"
+
+
+def test_catchup_opts_out_because_it_rebuilds_everything_itself():
+    from opennem.workers import catchup
+
+    source = inspect.getsource(catchup)
+
+    assert "rebuild_daily_views=False" in source
+    assert "backfill_materialized_views" in source


### PR DESCRIPTION
closes #592. the data repair is already applied to dev and prod; this stops it recurring.

## the bug

`fueltech_intervals_daily_mv` and `renewable_intervals_daily_mv` version rows as `interval_count * 1e9 + max(version)`, so a partial auto-populate can't clobber a full backfill. that part works as intended.

the flip side: when data arrives for a day those views **already hold**, the MV emits a new row covering only the late arrival. that row encodes a smaller interval count, loses the ReplacingMergeTree comparison, and is discarded — so the fueltech-level daily aggregate keeps its pre-backfill value indefinitely while `unit_intervals` moves on.

`unit_intervals_daily_mv` is immune: it's keyed per unit, so a backfilled unit is a *new key* rather than a competing version of an existing row. that asymmetry is exactly what was reported — network totals disagreeing with the sum of their units, on older data only, because recent days are written once and completely.

## measured

battery discharge before the repair — 18 months diverging, 41.39 GWh:

```
2023-12   units 36.77   network 34.11   -2.67
2024-05   units 59.86   network 56.19   -3.67
2024-07   units 67.92   network 63.86   -4.06
```

the effect concentrates in small fueltechs. the same absolute error is 0.011% of total nem generation and 5-10% of battery discharge.

## the fix

`process_unit_intervals_backlog` now rebuilds those two views over the same window it just wrote, using delete-then-insert — which replaces the rows outright instead of trying to out-version them.

three callers opt out:

- the two 5-minute WEM interval tasks, which re-run a recent window constantly and where the rebuild would dwarf the write. the daily catchup covers the same days.
- the daily catchup itself, which already calls `backfill_materialized_views` across every view.

defaulting to `True` is deliberate: the failure mode is silent and permanent, so a caller who hasn't thought about it should get the safe behaviour. the ad-hoc backfill scripts in `scripts/` are the exact case that produced this bug, and they get it for free.

## verification

on dev, deleted the view rows for a week of battery discharge and confirmed a backlog run restores them to match source exactly:

```
before: (12.816, None,   None)     <- source, view, diff
after:  (12.816, 12.816, -0.0)
```

4 tests, including one pinning that the hot paths stay opted out.