### PR TITLE
feat(monitors): detect solar telemetry frozen at its last daylight value

### DIFF
--- a/opennem/monitors/frozen_telemetry.py
+++ b/opennem/monitors/frozen_telemetry.py
@@ -17,9 +17,9 @@ constraint setpoint just as steadily. Scanning NEM history for long flat runs re
 mostly those, and separating them needs curtailment state the monitor does not have.
 
 Night output has no such ambiguity. A solar farm produces nothing at 1am, so any material
-reading in the small hours is the signal stuck at its last daylight value. Run over six
-years of NEM history this flagged 41 unit-days across a dozen incidents with no false
-positives, BUSF1 among them.
+reading in the small hours is the signal stuck at its last daylight value. Run over eleven
+years of NEM history this found 22 incidents totalling ~8.6 GWh of generation that never
+happened, with no false positives — BUSF1 among them, though not the largest.
 
 The same trick has no equivalent for wind or thermal plant, which legitimately run flat
 through the night, so the check is deliberately solar-only. It is a floor on detection,
@@ -58,11 +58,15 @@ DEFAULT_WINDOW_DAYS = 7
 
 @dataclass(frozen=True, slots=True)
 class FrozenSignal:
-    """A solar unit reporting material generation in the middle of the night."""
+    """A solar unit reporting material generation in the middle of the night.
+
+    `night` is the date the night *started* on, so a run from 22:00 to 02:00 stays one
+    finding instead of being cut in half at midnight.
+    """
 
     facility_code: str
     network_region: str
-    day: str
+    night: str
     capacity_mw: float
     intervals: int
     min_mw: float
@@ -81,7 +85,7 @@ class FrozenSignal:
         shape = f"flat at {self.min_mw:,.2f} MW" if self.is_constant else f"{self.min_mw:,.2f}-{self.max_mw:,.2f} MW"
         return (
             f"{self.facility_code} ({self.network_region}, {self.capacity_mw:,.0f} MW) "
-            f"{self.day}: {shape} across {self.intervals} night intervals"
+            f"night of {self.night}: {shape} across {self.intervals} night intervals"
         )
 
 
@@ -89,7 +93,7 @@ _NIGHT_SOLAR_QUERY = text("""
     select
         fs.facility_code,
         f.network_region,
-        to_char(date_trunc('day', fs.interval), 'YYYY-MM-DD') as day,
+        to_char(date_trunc('day', fs.interval - interval '3 hours'), 'YYYY-MM-DD') as night,
         u.capacity_registered,
         count(*) as intervals,
         min(fs.generated) as min_mw,
@@ -100,7 +104,7 @@ _NIGHT_SOLAR_QUERY = text("""
     where
         fs.network_id = 'NEM'
         and fs.is_forecast is false
-        and fs.interval >= now() - (:window_days * interval '1 day')
+        and fs.interval >= (now() at time zone 'Australia/Brisbane') - (:window_days * interval '1 day')
         and u.fueltech_id = 'solar_utility'
         and u.capacity_registered > 0
         and (extract(hour from fs.interval) >= :night_start or extract(hour from fs.interval) < :night_end)
@@ -117,13 +121,13 @@ def to_findings(rows: Iterable[Sequence[Any]]) -> list[FrozenSignal]:
         FrozenSignal(
             facility_code=facility_code,
             network_region=network_region,
-            day=day,
+            night=night,
             capacity_mw=float(capacity),
             intervals=intervals,
             min_mw=float(min_mw),
             max_mw=float(max_mw),
         )
-        for facility_code, network_region, day, capacity, intervals, min_mw, max_mw in rows
+        for facility_code, network_region, night, capacity, intervals, min_mw, max_mw in rows
     ]
 
     findings.sort(key=lambda f: f.intervals, reverse=True)
@@ -155,7 +159,7 @@ async def check_frozen_telemetry(window_days: int = DEFAULT_WINDOW_DAYS) -> list
     findings = to_findings(rows)
 
     if findings:
-        logger.warning(f"{len(findings)} solar unit-days reporting night generation over {window_days}d")
+        logger.warning(f"{len(findings)} solar unit-nights reporting generation over {window_days}d")
         for finding in findings:
             logger.warning(f"  {finding}")
     else:

--- a/opennem/monitors/frozen_telemetry.py
+++ b/opennem/monitors/frozen_telemetry.py
@@ -1,0 +1,203 @@
+"""Detect generation telemetry that has frozen at its last value (#544).
+
+When a unit's SCADA link fails, AEMO keeps publishing the last value it saw rather than
+a gap or a zero. BUSF1 (Bundaberg, 101 MW solar) held exactly 60.76 MW day and night for
+745 consecutive intervals in April 2026, inflating its energy roughly 3.8x and adding
+~2.7 GWh of generation that never happened.
+
+Nothing downstream catches this. The value is well inside the unit's capacity, so range
+checks pass; it is present in every interval, so completeness checks pass; and the freeze
+propagates into the next-day dispatch solution and the settled MMSDM archive alike, so a
+re-crawl rewrites the same wrong number.
+
+**The check is "solar generating at night", not "value hasn't changed".** A flat run is
+not evidence of a fault: a solar farm clipping at its inverter limit holds its exact
+capacity for hours every sunny day, and a curtailed farm or wind farm sits on its
+constraint setpoint just as steadily. Scanning NEM history for long flat runs returns
+mostly those, and separating them needs curtailment state the monitor does not have.
+
+Night output has no such ambiguity. A solar farm produces nothing at 1am, so any material
+reading in the small hours is the signal stuck at its last daylight value. Run over six
+years of NEM history this flagged 41 unit-days across a dozen incidents with no false
+positives, BUSF1 among them.
+
+The same trick has no equivalent for wind or thermal plant, which legitimately run flat
+through the night, so the check is deliberately solar-only. It is a floor on detection,
+not a ceiling: a freeze that begins and ends between dawn and dusk still slips through.
+"""
+
+import logging
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from sqlalchemy import text
+
+from opennem.clients.slack import slack_message
+from opennem.db import get_read_session
+
+logger = logging.getLogger("opennem.monitors.frozen_telemetry")
+
+# Night in AEST. NEM intervals are AEST-naive, and 22:00-03:00 is comfortably dark across
+# every NEM region year round — the widest civil twilight in the market (Hobart, midsummer)
+# still ends before 21:30.
+NIGHT_START_HOUR = 22
+NIGHT_END_HOUR = 3
+
+# Fraction of registered capacity a night reading has to reach before it counts. Solar
+# farms legitimately draw a small auxiliary load overnight, which shows up as readings
+# around 0.01-0.2 MW; without this floor those swamp the real signal.
+CAPACITY_FRACTION = 0.1
+
+# Half an hour of stuck night intervals. Below this, a single interval either side of dusk
+# is more likely a timestamp edge than a fault.
+MIN_NIGHT_INTERVALS = 6
+
+DEFAULT_WINDOW_DAYS = 7
+
+
+@dataclass(frozen=True, slots=True)
+class FrozenSignal:
+    """A solar unit reporting material generation in the middle of the night."""
+
+    facility_code: str
+    network_region: str
+    day: str
+    capacity_mw: float
+    intervals: int
+    min_mw: float
+    max_mw: float
+
+    @property
+    def is_constant(self) -> bool:
+        """A dead-flat value is the signature of a frozen signal specifically.
+
+        A varying night reading is still wrong, but points at something else — a
+        mis-registered co-located battery, or a unit reporting on the wrong DUID.
+        """
+        return abs(self.max_mw - self.min_mw) < 0.01
+
+    def __str__(self) -> str:
+        shape = f"flat at {self.min_mw:,.2f} MW" if self.is_constant else f"{self.min_mw:,.2f}-{self.max_mw:,.2f} MW"
+        return (
+            f"{self.facility_code} ({self.network_region}, {self.capacity_mw:,.0f} MW) "
+            f"{self.day}: {shape} across {self.intervals} night intervals"
+        )
+
+
+_NIGHT_SOLAR_QUERY = text("""
+    select
+        fs.facility_code,
+        f.network_region,
+        to_char(date_trunc('day', fs.interval), 'YYYY-MM-DD') as day,
+        u.capacity_registered,
+        count(*) as intervals,
+        min(fs.generated) as min_mw,
+        max(fs.generated) as max_mw
+    from facility_scada fs
+    join units u on u.code = fs.facility_code
+    join facilities f on f.id = u.station_id
+    where
+        fs.network_id = 'NEM'
+        and fs.is_forecast is false
+        and fs.interval >= now() - (:window_days * interval '1 day')
+        and u.fueltech_id = 'solar_utility'
+        and u.capacity_registered > 0
+        and (extract(hour from fs.interval) >= :night_start or extract(hour from fs.interval) < :night_end)
+        and fs.generated > :capacity_fraction * u.capacity_registered
+    group by 1, 2, 3, 4
+    having count(*) >= :min_intervals
+    order by 3 desc, 5 desc
+""")
+
+
+def to_findings(rows: Iterable[Sequence[Any]]) -> list[FrozenSignal]:
+    """Turn query rows into findings, worst (longest) first."""
+    findings = [
+        FrozenSignal(
+            facility_code=facility_code,
+            network_region=network_region,
+            day=day,
+            capacity_mw=float(capacity),
+            intervals=intervals,
+            min_mw=float(min_mw),
+            max_mw=float(max_mw),
+        )
+        for facility_code, network_region, day, capacity, intervals, min_mw, max_mw in rows
+    ]
+
+    findings.sort(key=lambda f: f.intervals, reverse=True)
+
+    return findings
+
+
+async def check_frozen_telemetry(window_days: int = DEFAULT_WINDOW_DAYS) -> list[FrozenSignal]:
+    """Find solar units reporting generation overnight.
+
+    Args:
+        window_days: how far back to look. A freeze can persist for days, so this wants to
+            be long enough to still catch one that started just after the last run.
+
+    Returns:
+        Findings, longest first. Empty when telemetry is behaving.
+    """
+    params = {
+        "window_days": window_days,
+        "night_start": NIGHT_START_HOUR,
+        "night_end": NIGHT_END_HOUR,
+        "capacity_fraction": CAPACITY_FRACTION,
+        "min_intervals": MIN_NIGHT_INTERVALS,
+    }
+
+    async with get_read_session() as session:
+        rows = (await session.execute(_NIGHT_SOLAR_QUERY, params)).all()
+
+    findings = to_findings(rows)
+
+    if findings:
+        logger.warning(f"{len(findings)} solar unit-days reporting night generation over {window_days}d")
+        for finding in findings:
+            logger.warning(f"  {finding}")
+    else:
+        logger.info(f"No frozen solar telemetry over the last {window_days} days")
+
+    return findings
+
+
+async def run_frozen_telemetry_check(window_days: int = DEFAULT_WINDOW_DAYS) -> list[FrozenSignal]:
+    """Run the check and alert to Slack on anything found."""
+    from opennem import settings
+
+    findings = await check_frozen_telemetry(window_days=window_days)
+
+    if not findings:
+        return findings
+
+    lines = "\n".join(f"• {finding}" for finding in findings)
+    await slack_message(
+        webhook_url=settings.slack_hook_monitoring,
+        message=(
+            f"*Solar units reporting generation overnight* ({window_days}d window)\n"
+            f"Solar cannot generate at night, so these readings are almost certainly telemetry "
+            f"frozen at their last daylight value — inflating energy for as long as the freeze "
+            f"lasts:\n{lines}\n"
+            f"Re-crawling will not fix it: the freeze propagates into next-day dispatch and the "
+            f"settled archive too. See #544."
+        ),
+        tag_users=settings.slack_admin_alert,
+    )
+
+    return findings
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    async def _main() -> None:
+        findings = await check_frozen_telemetry()
+        if not findings:
+            print("clean — no night solar generation")
+        for finding in findings:
+            print(finding)
+
+    asyncio.run(_main())

--- a/opennem/tasks/app.py
+++ b/opennem/tasks/app.py
@@ -39,6 +39,7 @@ from opennem.tasks.tasks import (
     task_catchup_aggregates,
     task_catchup_check,
     task_catchup_days,
+    task_check_frozen_telemetry,
     task_check_unmapped_facility_codes,
     task_check_unsplit_batteries,
     task_clean_tmp_dir,
@@ -336,6 +337,15 @@ class WorkerSettings:
             task_check_unmapped_facility_codes,
             hour=10,
             minute=15,
+            second=0,
+            timeout=None,
+            unique=True,
+        ),
+        # Check for solar telemetry frozen at its last daylight value
+        cron(
+            task_check_frozen_telemetry,
+            hour=10,
+            minute=20,
             second=0,
             timeout=None,
             unique=True,

--- a/opennem/tasks/tasks.py
+++ b/opennem/tasks/tasks.py
@@ -34,6 +34,7 @@ from opennem.db.clickhouse.schema import optimize_clickhouse_tables
 from opennem.exporter.facilities import export_facilities_static
 
 # from opennem.exporter.historic import export_historic_intervals
+from opennem.monitors.frozen_telemetry import run_frozen_telemetry_check
 from opennem.monitors.unmapped_codes import run_unmapped_code_check
 from opennem.pipelines.export import run_export_power_latest_for_network
 from opennem.schema.network import NetworkAU, NetworkNEM, NetworkWEM
@@ -354,6 +355,23 @@ async def task_check_unmapped_facility_codes(ctx: dict) -> None:
         await run_unmapped_code_check()
     except Exception as e:
         logger.error(f"Error checking unmapped facility codes: {str(e)}")
+        raise
+
+
+async def task_check_frozen_telemetry(ctx: dict) -> None:
+    """Task to check for solar units reporting generation overnight.
+
+    Solar can't generate at night, so a material reading in the small hours means the
+    telemetry has frozen at its last daylight value and is inflating energy for as long
+    as the freeze lasts (#544).
+
+    Args:
+        ctx (dict): Task context
+    """
+    try:
+        await run_frozen_telemetry_check()
+    except Exception as e:
+        logger.error(f"Error checking frozen telemetry: {str(e)}")
         raise
 
 

--- a/tests/test_frozen_telemetry.py
+++ b/tests/test_frozen_telemetry.py
@@ -2,10 +2,12 @@
 
 The detector's whole value is that it separates a genuine fault from the flat runs that
 normal solar operation produces all the time, so the tests are mostly about what it
-declines to flag.
+declines to flag — plus the two boundaries in the SQL that are easy to get wrong: the
+night straddles midnight, and the timestamps are AEST-naive while the session is UTC.
 """
 
 from opennem.monitors.frozen_telemetry import (
+    _NIGHT_SOLAR_QUERY,
     CAPACITY_FRACTION,
     MIN_NIGHT_INTERVALS,
     NIGHT_END_HOUR,
@@ -14,7 +16,7 @@ from opennem.monitors.frozen_telemetry import (
     to_findings,
 )
 
-# (facility_code, network_region, day, capacity, intervals, min_mw, max_mw)
+# (facility_code, network_region, night, capacity, intervals, min_mw, max_mw)
 BUSF1_ROW = ("BUSF1", "QLD1", "2026-04-30", 101.0, 60, 60.76, 60.76)
 
 
@@ -25,6 +27,7 @@ def test_busf1_is_flagged_as_a_freeze():
     assert finding.facility_code == "BUSF1"
     assert finding.is_constant
     assert "flat at 60.76 MW" in str(finding)
+    assert "night of 2026-04-30" in str(finding)
 
 
 def test_varying_night_output_is_reported_but_not_called_a_freeze():
@@ -43,6 +46,26 @@ def test_findings_are_ordered_worst_first():
     ]
 
     assert [f.intervals for f in to_findings(rows)] == [60, 16, 10]
+
+
+def test_night_is_grouped_whole_rather_than_split_at_midnight():
+    """The window runs 22:00-03:00, so grouping on the calendar day would cut every night
+    in two and could drop both halves below the interval threshold."""
+    sql = str(_NIGHT_SOLAR_QUERY)
+
+    assert "date_trunc('day', fs.interval - interval '3 hours')" in sql, (
+        "night grouping must shift back past midnight so 22:00 and 02:00 land in one group"
+    )
+
+
+def test_window_cutoff_is_computed_in_aest():
+    """facility_scada.interval is AEST-naive. Comparing it to a UTC now() would silently
+    widen every window by 10 hours."""
+    sql = str(_NIGHT_SOLAR_QUERY)
+
+    assert "now() at time zone 'Australia/Brisbane'" in sql
+    # Brisbane, not Sydney: NEM time is AEST year round and never shifts for DST.
+    assert "Australia/Sydney" not in sql
 
 
 def test_night_window_is_dark_across_the_whole_nem():

--- a/tests/test_frozen_telemetry.py
+++ b/tests/test_frozen_telemetry.py
@@ -1,0 +1,73 @@
+"""Frozen telemetry detection (#544).
+
+The detector's whole value is that it separates a genuine fault from the flat runs that
+normal solar operation produces all the time, so the tests are mostly about what it
+declines to flag.
+"""
+
+from opennem.monitors.frozen_telemetry import (
+    CAPACITY_FRACTION,
+    MIN_NIGHT_INTERVALS,
+    NIGHT_END_HOUR,
+    NIGHT_START_HOUR,
+    FrozenSignal,
+    to_findings,
+)
+
+# (facility_code, network_region, day, capacity, intervals, min_mw, max_mw)
+BUSF1_ROW = ("BUSF1", "QLD1", "2026-04-30", 101.0, 60, 60.76, 60.76)
+
+
+def test_busf1_is_flagged_as_a_freeze():
+    """The incident that prompted the check has to come out as a frozen signal."""
+    (finding,) = to_findings([BUSF1_ROW])
+
+    assert finding.facility_code == "BUSF1"
+    assert finding.is_constant
+    assert "flat at 60.76 MW" in str(finding)
+
+
+def test_varying_night_output_is_reported_but_not_called_a_freeze():
+    """Middlemount swung 6-24 MW overnight — wrong, but a different fault to a stuck signal."""
+    (finding,) = to_findings([("MIDDLSF1", "QLD1", "2026-03-17", 30.0, 7, 6.8, 23.8)])
+
+    assert not finding.is_constant
+    assert "6.80-23.80 MW" in str(finding)
+
+
+def test_findings_are_ordered_worst_first():
+    rows = [
+        ("GOONSF1", "NSW1", "2026-07-23", 85.0, 10, 23.77, 23.77),
+        BUSF1_ROW,
+        ("NEVERSF1", "NSW1", "2026-02-25", 132.0, 16, 32.94, 32.94),
+    ]
+
+    assert [f.intervals for f in to_findings(rows)] == [60, 16, 10]
+
+
+def test_night_window_is_dark_across_the_whole_nem():
+    """Latest civil twilight anywhere in the NEM ends before 21:30 AEST."""
+    assert NIGHT_START_HOUR >= 22
+    assert NIGHT_END_HOUR <= 3
+
+
+def test_thresholds_clear_overnight_auxiliary_load():
+    """Solar farms idle around 0.01-0.2 MW overnight. On the smallest NEM solar unit
+    (~12 MW) the capacity floor still sits well above that."""
+    smallest_solar_capacity_mw = 12.0
+
+    assert CAPACITY_FRACTION * smallest_solar_capacity_mw > 0.2
+
+
+def test_minimum_run_is_at_least_half_an_hour():
+    """One interval either side of dusk is a timestamp edge, not a fault."""
+    assert MIN_NIGHT_INTERVALS * 5 >= 30
+
+
+def test_constant_tolerance_is_tight_enough_to_split_real_cases():
+    """BUSF1 froze to the cent; the near-miss cases moved by more than that."""
+    frozen = FrozenSignal("BUSF1", "QLD1", "2026-04-30", 101.0, 60, 60.76, 60.76)
+    drifting = FrozenSignal("BUSF1", "QLD1", "2026-04-09", 101.0, 13, 73.65, 73.71)
+
+    assert frozen.is_constant
+    assert not drifting.is_constant


### PR DESCRIPTION
closes part of #544.

## the gap

when a unit's scada link fails aemo keeps publishing the last value it saw rather than a gap or a zero. busf1 (bundaberg, 101 MW solar) held exactly 60.76 MW day and night for 745 intervals from 2026-04-29 to 05-02.

nothing downstream catches this. the value sits inside capacity so range checks pass, it is present in every interval so completeness checks pass, and the freeze propagates into next-day dispatch so a re-crawl rewrites the same wrong number.

confirmed this cycle that it also propagates into the **settled mmsdm archive** — pulled `DISPATCH_UNIT_SCADA` for 2026_04/05 and the same 745 frozen intervals are there, published 8 may, never revised. `INTERMITTENT_GEN_SCADA` carries only `LOCL`/`ELAV` limit signals, not metered output, and mmsdm publishes no per-duid metered generation table. so there is no clean source to re-import from, and the historic repair remains an imputation decision (still open, see below).

## the check

**solar generating at night, not "value hasn't changed".** a flat run is not evidence of a fault — a farm clipping at its inverter limit holds exact capacity for hours every sunny day, and a curtailed farm sits on its setpoint just as steadily. scanning history for long flat runs returns mostly those (grifsf1 pinned at 27.2/27 MW midday, cnundawf at 39/46) and separating them needs curtailment state we don't have.

night output has no such ambiguity. no solar farm produces power at 1am.

## what it finds

22 incidents over 11 years, ~8.6 GWh net of generation that never happened, no false positives. the live 7d window is currently clean.

| unit | window | spurious MWh |
|---|---|---|
| GLRWNSF1 | 2021-05-21→23 | 2,329 |
| BUSF1 | 2026-04-09→30 | 2,162 |
| MOREESF1 | 2020-01-20→22 | 1,457 |
| BUSF1 | 2026-05-01 | 1,008 |
| NYNGAN1 | 2015-09-24 | 744 |
| GANNSF1 | 2019-02-22→23 | 705 |
| GOONSF1 | 2026-06-21→22 | 181 |

two things worth noting: **glenrowan west 2021 was bigger than busf1** and was never reported, and **goonsf1 froze on four nights in june/july 2026** — recent, also unreported.

## limits

solar-only by design: wind and thermal legitimately run flat overnight, so there is no equivalent physical impossibility to key off. a freeze contained entirely between dawn and dusk still slips through. this is a floor on detection, not a ceiling.

runs daily at 10:20 alongside the #604 unmapped-code check, alerts to slack.

## test plan
- 7 unit tests on the classification logic, focused on what it declines to flag
- ran against prod: live 7d window clean, 107d window reproduces busf1 exactly
- ruff + pyright clean