### PR TITLE
chore(ci): migrate claude code action to v1

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,28 +3,17 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-    
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
       pull-requests: read
       issues: read
       id-token: write
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -33,46 +22,24 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: "claude"
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-opus-4-20250514"
-          
-          # Direct prompt for automated review (no @claude mention needed)
-          direct_prompt: |
-            Please review this pull request and provide feedback on:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Performance considerations
+          # Supplying a prompt on a pull_request event selects automation mode, so the
+          # review runs without needing an @claude mention. In v1 this input is `prompt`;
+          # it was `direct_prompt` in v0 and is silently ignored under that name.
+          prompt: |
+            Review this pull request and give feedback on:
+            - Correctness — bugs, unhandled edge cases, incorrect assumptions
+            - Data pipeline safety — this repo has hard rules in CLAUDE.md covering
+              ClickHouse FINAL scoping, async vs sync in worker tasks, session
+              contention, static export boundaries and AEST vs UTC handling. Read it
+              and flag anything that violates them.
+            - Performance, particularly queries against facility_scada and unit_intervals
             - Security concerns
             - Test coverage
-            
-            Be constructive and helpful in your feedback.
 
-          # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
-          # use_sticky_comment: true
-          
-          # Optional: Customize review based on file types
-          # direct_prompt: |
-          #   Review this PR focusing on:
-          #   - For TypeScript files: Type safety and proper interface usage
-          #   - For API endpoints: Security, input validation, and error handling
-          #   - For React components: Performance, accessibility, and best practices
-          #   - For tests: Coverage, edge cases, and test quality
-          
-          # Optional: Different prompts for different authors
-          # direct_prompt: |
-          #   ${{ github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' && 
-          #   'Welcome! Please review this PR from a first-time contributor. Be encouraging and provide detailed explanations for any suggestions.' ||
-          #   'Please provide a thorough code review focusing on our coding standards and best practices.' }}
-          
-          # Optional: Add specific tools for running tests or linting
-          # allowed_tools: "Bash(npm run test),Bash(npm run lint),Bash(npm run typecheck)"
-          
-          # Optional: Skip review for certain conditions
-          # if: |
-          #   !contains(github.event.pull_request.title, '[skip-review]') &&
-          #   !contains(github.event.pull_request.title, '[WIP]')
+            Be constructive and specific. Prefer a small number of real defects over a
+            long list of style observations.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,6 +18,7 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: read
@@ -32,33 +33,20 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # This is an optional setting that allows Claude to read CI results on PRs
+          # No `prompt` here on purpose — omitting it selects tag mode, where Claude
+          # responds to the @claude mention that triggered the run.
+
+          # Lets Claude read CI results on PRs
           additional_permissions: |
             actions: read
-          
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-opus-4-20250514"
-          
-          # Optional: Customize the trigger phrase (default: @claude)
-          # trigger_phrase: "/claude"
-          
-          # Optional: Trigger when specific user is assigned to an issue
-          # assignee_trigger: "claude-bot"
-          
-          # Optional: Allow Claude to run specific commands
-          # allowed_tools: "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*)"
-          
-          # Optional: Add custom instructions for Claude to customize its behavior for your project
-          # custom_instructions: |
-          #   Follow our coding standards
-          #   Ensure all new code has tests
-          #   Use TypeScript for new files
-          
-          # Optional: Custom environment variables for Claude
-          # claude_env: |
-          #   NODE_ENV: test
 
+          # Tool and model settings move under claude_args in v1. They were separate
+          # `allowed_tools` / `model` / `custom_instructions` inputs in v0.
+          # claude_args: |
+          #   --model claude-opus-4-20250514
+          #   --allowedTools Bash(uv run pytest:*),Bash(uv run ruff:*)
+          #   --append-system-prompt "Follow the pipeline rules in CLAUDE.md"


### PR DESCRIPTION
both claude workflows were pinned to `anthropics/claude-code-action@beta` and still using v0 input names.

## the breaking bit

`direct_prompt` was renamed to `prompt` in v1. unknown inputs are **ignored silently** rather than erroring, so bumping the tag without this rename would have left the review running with no instructions at all — green check, generic output, no signal. that's the one change that actually matters here.

## what i did not change

the [migration guide](https://github.com/anthropics/claude-code-action/blob/main/docs/migration-guide.md) implies `allowed_bots`, `additional_permissions` and `use_sticky_comment` were removed in v1. they weren't — all three are still declared in [v1 `action.yml`](https://github.com/anthropics/claude-code-action/blob/v1/action.yml). i checked every input we use against the action definition rather than trusting the guide, and left those as they were. `claude_code_oauth_token` is also still valid.

for reference, the inputs that genuinely moved under `claude_args`:

| v0 | v1 |
|---|---|
| `direct_prompt` | `prompt` |
| `model` | `claude_args: --model` |
| `allowed_tools` | `claude_args: --allowedTools` |
| `custom_instructions` | `claude_args: --append-system-prompt` |
| `timeout_minutes` | job-level `timeout-minutes` |

we weren't using any of those, so nothing to port — but the commented-out examples in `claude.yml` referenced the old names and would have misled whoever uncommented them, so those are updated.

## while i was in there

- added job-level `timeout-minutes` (20 review / 30 mention) — there was no timeout at all before
- removed the scaffold comment blocks these files shipped with
- pointed the review prompt at the pipeline rules in `CLAUDE.md` (ClickHouse FINAL scoping, async-vs-sync in workers, session contention, export boundaries, AEST vs UTC) rather than the generic "code quality and best practices" text. this repo has specific, easy-to-violate invariants and a generic reviewer won't catch them. **happy to drop this hunk if you'd rather keep the migration pure** — it's the last block in `claude-code-review.yml`.

## note on the failing check

this PR's own `claude-review` run will still fail until `CLAUDE_CODE_OAUTH_TOKEN` is refreshed — the current secret was set 2025-07-24 and has expired, which is failing on every PR in the repo right now (see #625, #626, #627, #628, all merged today with a red check). once you set the new token, re-running this PR's check is a clean end-to-end test of the migration.