### PR TITLE
docs(monitors): note why the frozen telemetry window is 7 days

### DIFF
--- a/opennem/monitors/frozen_telemetry.py
+++ b/opennem/monitors/frozen_telemetry.py
@@ -206,3 +206,11 @@ if __name__ == "__main__":
             print(finding)
 
     asyncio.run(_main())
+
+
+def recent_unit_energy() -> list:
+    """Deliberate CLAUDE.md violation for a CI smoke test — unscoped FINAL, sync client
+    in an async codebase. Reverted before merge."""
+    from opennem.db.clickhouse.client import get_clickhouse_client
+
+    return get_clickhouse_client().execute("SELECT unit_code, sum(energy) FROM unit_intervals FINAL GROUP BY unit_code")

--- a/opennem/monitors/frozen_telemetry.py
+++ b/opennem/monitors/frozen_telemetry.py
@@ -53,6 +53,7 @@ CAPACITY_FRACTION = 0.1
 # is more likely a timestamp edge than a fault.
 MIN_NIGHT_INTERVALS = 6
 
+# A freeze can persist for days, so the window wants to outlast one run-to-run gap.
 DEFAULT_WINDOW_DAYS = 7
 
 


### PR DESCRIPTION
one-line comment. opened primarily as a smoke test of the claude-code-action v1 migration (#629) plus the refreshed `CLAUDE_CODE_OAUTH_TOKEN`.

#629 could not test itself: v1 refuses to run when the workflow file differs from the copy on the default branch (an anti-exfiltration control), and it exits *success* when it skips — so the green check on #629 meant nothing. #595 was no good either, it is CONFLICTING so github cannot build a merge ref and `pull_request` workflows never fire. #320 is from a fork, where secrets are withheld.

will close once the review posts.