### PR TITLE
fix(ci): give claude review write permission so it can post

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,8 +10,10 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      # write, not read: the action posts its review through the workflow token, so
+      # read-only permissions let it analyse the PR and then silently drop the result.
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -21,8 +21,9 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      # write so Claude can actually reply to the mention that triggered it
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:


### PR DESCRIPTION
follow-up to #629.

with the token refreshed and v1 merged, the review now runs properly — authenticates, works for ~90 seconds, exits success. it just never posts anything.

i confirmed it is not "nothing to say" by pushing a deliberate violation to a test PR (#630): an unscoped `SELECT ... FROM unit_intervals FINAL` with a sync clickhouse client, which `CLAUDE.md` explicitly forbids. still silent.

cause is the permissions block, which both workflows inherited from the original scaffold:

```yaml
pull-requests: read   # <- claude can read the pr and not much else
issues: read
```

v1 posts through the workflow token, so read-only means it does the whole review and then discards it. [docs/setup.md](https://github.com/anthropics/claude-code-action/blob/main/docs/setup.md) calls for `pull-requests: write` and `issues: write`.

worth noting the failure mode: no error, no warning, job goes green. if we had not looked for the comment we would have assumed this was working.

`contents` stays `read` — the review does not need to push commits, and the docs' `contents: write` is only for workflows where claude commits fixes.

same self-test limitation as #629: this PR modifies workflows, so v1's workflow-validation guard will skip its own review. i will verify on #630 after merge.