### PR TITLE
fix(capacity): count battery capacity once

### DIFF
--- a/opennem/queries/capacity_history.py
+++ b/opennem/queries/capacity_history.py
@@ -61,7 +61,13 @@ async def get_capacity_history(
             AND COALESCE(u.capacity_maximum, u.capacity_registered) IS NOT NULL
             AND u.commencement_date IS NOT NULL
             AND f.network_id IN ('NEM', 'WEM')
-            AND u.fueltech_id NOT IN ('battery', 'solar_rooftop')
+            -- A battery is three unit rows carrying the same megawatts: the bidirectional
+            -- unit plus the derived charging and discharging halves. Keeping both halves
+            -- is correct for power and energy, where each direction is a real flow, but
+            -- doubles the capacity of every battery in a SUM. Count the discharging half
+            -- only, so battery capacity means generation capacity like every other
+            -- fueltech here (#488).
+            AND u.fueltech_id NOT IN ('battery', 'battery_charging', 'solar_rooftop')
             -- Only include valid regions: WEM network only has WEM region
             AND ((f.network_id = 'WEM' AND f.network_region = 'WEM') OR (f.network_id = 'NEM' AND f.network_region != 'WEM'))
             -- Unit is live if the month overlaps with its operational period

--- a/tests/test_capacity_history_battery.py
+++ b/tests/test_capacity_history_battery.py
@@ -1,0 +1,48 @@
+"""Battery capacity must be counted once (#488).
+
+A battery is three rows in `units` carrying the same megawatts: the bidirectional unit and
+the derived charging and discharging halves. Power and energy series legitimately keep both
+halves, so the exclusion has to live in the capacity query specifically.
+"""
+
+from opennem.queries import capacity_history
+
+
+def _unit_query() -> str:
+    """The unit-level capacity query, which is the one that sums across fueltechs."""
+    import inspect
+
+    source = inspect.getsource(capacity_history.get_capacity_history)
+    return source.lower()
+
+
+def test_charging_half_is_excluded_from_capacity():
+    """Without this every battery contributes its rating twice, 11.6 GW across NEM and WEM."""
+    query = _unit_query()
+
+    assert "'battery_charging'" in query, "capacity sum must exclude the charging half"
+
+
+def test_bidirectional_row_is_still_excluded():
+    """The parent row carries the same megawatts again, so it cannot come back."""
+    assert "'battery'" in _unit_query()
+
+
+def test_discharging_half_is_kept():
+    """Battery capacity means generation capacity, consistent with every other fueltech in
+    this query, so the discharging half is the one that counts."""
+    query = _unit_query()
+
+    assert "'battery_discharging'" not in query, "the discharging half must remain in the sum"
+
+
+def test_power_and_energy_queries_keep_both_halves():
+    """Charge and discharge are distinct flows over time. Excluding a half there would drop
+    real generation, so the #488 fix must not have leaked into those queries."""
+    import inspect
+
+    from opennem.queries import energy, power
+
+    for module in (power, energy):
+        source = inspect.getsource(module)
+        assert "'battery_charging'" not in source, f"{module.__name__} must keep both battery halves"


### PR DESCRIPTION
closes #488.

## cause

a battery is **three rows in `units`, each carrying the same megawatts**: the bidirectional unit, plus the derived `battery_charging` and `battery_discharging` halves. blythe is one 281 MW asset stored as `BLYTHB1` / `BLYTHB1L1` / `BLYTHB1G1`, all 281 MW registered and 200 MW maximum.

`get_capacity_history` dropped the bidirectional row but kept **both** halves:

```sql
AND u.fueltech_id NOT IN ('battery', 'solar_rooftop')
```

so every battery contributed its rating twice. for SA1 that is `battery_charging` 1.384 GW + `battery_discharging` 1.380 GW against roughly 1.38 GW of physical battery.

## it explains the number in the issue

the issue guessed registered vs maximum. it is not that:

```
capacity chart SA1        10.73 GW
minus 2 x 1.384 duplicate  7.96 GW   <- the facilities page showed 7.74 GW in march
```

the 0.2 GW residual is five months of capacity additions since the issue was filed.

## fix

add `battery_charging` to the exclusion, so battery capacity means generation capacity, consistent with every other fueltech in this query.

| | before | after |
|---|---|---|
| SA1 total | 9.411 GW | **8.026 GW** |
| phantom battery capacity, NEM + WEM | | **11.622 GW removed** |

## scoping

keeping both halves is **correct** for power and energy, where charge and discharge are distinct real flows over time. `queries/power.py` and `queries/energy.py` also exclude the bidirectional row and must keep both halves; a test pins that so this fix cannot leak there later.

the general rule the battery split needs and did not have: **both halves at full rating is right for power and energy, and wrong for any capacity SUM.**

## also found, not fixed here

- `cms/updates.py:58` sums `capacity_registered` across a facility's units for a log line, so it triple-counts battery facilities in CMS update logs. cosmetic, no data impact.
- `capacity_registered` vs `capacity_maximum` is a second, independent inconsistency the issue raises: SA1 is 14.41 GW registered against 10.73 GW maximum, and the two surfaces do not agree on which they use. worth deciding and then documenting on the capacity guide, which the issue also asks for.

## test plan

- 4 unit tests: charging excluded, bidirectional still excluded, discharging retained, power/energy queries untouched
- verified against prod postgres, numbers above
- ruff clean
