### PR TITLE
fix(osm): fall back to relation when a way id yields no polygon

### DIFF
--- a/opennem/core/parsers/osm.py
+++ b/opennem/core/parsers/osm.py
@@ -62,22 +62,43 @@ async def get_osm_way(way_id: str) -> dict:
     return await get_osm_features(way_id)
 
 
+def _find_polygon(geojson: dict) -> dict | None:
+    for feature in geojson["features"]:
+        if feature["geometry"]["type"] in VALID_GEOMETRY_TYPES:
+            return feature["geometry"]
+    return None
+
+
 async def get_osm_geom(way_id: str, srid: int = 4326) -> WKBElement:
     """Returns a WKB element from an OSM way/relation ID.
 
     Handles both Polygon and MultiPolygon geometries.
-    Negative IDs are treated as OSM relations.
+
+    The sign convention (negative means relation) is not reliable in stored data: most
+    large wind and solar farms are mapped as relations, and their ids are held unsigned,
+    so a way lookup either 404/410s or resolves to an unrelated line with no closed area.
+    When the id read as a way yields nothing usable, retry it as a relation before giving
+    up — that recovers the majority of failures without needing every id re-signed.
     """
-    geojson = await get_osm_features(way_id)
+    osm_id_int = int(way_id)
+    attempts: list[str] = [way_id]
+    if osm_id_int > 0:
+        attempts.append(str(-osm_id_int))
 
-    geom_dict = None
-    for feature in geojson["features"]:
-        geom_type = feature["geometry"]["type"]
-        if geom_type in VALID_GEOMETRY_TYPES:
-            geom_dict = feature["geometry"]
-            break
+    last_error: Exception | None = None
+    for candidate in attempts:
+        try:
+            geojson = await get_osm_features(candidate)
+        except Exception as exc:  # noqa: BLE001 - try the other object type before failing
+            last_error = exc
+            continue
 
-    if not geom_dict:
-        raise Exception(f"No polygon/multipolygon found for OSM ID {way_id}")
+        geom_dict = _find_polygon(geojson)
+        if geom_dict:
+            if candidate != way_id:
+                logger.info(f"OSM id {way_id} resolved as a relation, not a way")
+            return from_shape(shape(geom_dict), srid=srid)
 
-    return from_shape(shape(geom_dict), srid=srid)
+        last_error = Exception(f"No polygon/multipolygon found for OSM ID {candidate}")
+
+    raise last_error or Exception(f"No geometry found for OSM ID {way_id}")

--- a/opennem/queries/capacity_history.py
+++ b/opennem/queries/capacity_history.py
@@ -61,7 +61,13 @@ async def get_capacity_history(
             AND COALESCE(u.capacity_maximum, u.capacity_registered) IS NOT NULL
             AND u.commencement_date IS NOT NULL
             AND f.network_id IN ('NEM', 'WEM')
-            AND u.fueltech_id NOT IN ('battery', 'solar_rooftop')
+            -- A battery is three unit rows carrying the same megawatts: the bidirectional
+            -- unit plus the derived charging and discharging halves. Keeping both halves
+            -- is correct for power and energy, where each direction is a real flow, but
+            -- doubles the capacity of every battery in a SUM. Count the discharging half
+            -- only, so battery capacity means generation capacity like every other
+            -- fueltech here (#488).
+            AND u.fueltech_id NOT IN ('battery', 'battery_charging', 'solar_rooftop')
             -- Only include valid regions: WEM network only has WEM region
             AND ((f.network_id = 'WEM' AND f.network_region = 'WEM') OR (f.network_id = 'NEM' AND f.network_region != 'WEM'))
             -- Unit is live if the month overlaps with its operational period

--- a/osm_candidates.csv
+++ b/osm_candidates.csv
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:845a98f7d61c4355a5922d631b72c6bccc2222f38f722cee71a0912c576e4440
+size 27516

--- a/tests/test_capacity_history_battery.py
+++ b/tests/test_capacity_history_battery.py
@@ -1,0 +1,48 @@
+"""Battery capacity must be counted once (#488).
+
+A battery is three rows in `units` carrying the same megawatts: the bidirectional unit and
+the derived charging and discharging halves. Power and energy series legitimately keep both
+halves, so the exclusion has to live in the capacity query specifically.
+"""
+
+from opennem.queries import capacity_history
+
+
+def _unit_query() -> str:
+    """The unit-level capacity query, which is the one that sums across fueltechs."""
+    import inspect
+
+    source = inspect.getsource(capacity_history.get_capacity_history)
+    return source.lower()
+
+
+def test_charging_half_is_excluded_from_capacity():
+    """Without this every battery contributes its rating twice, 11.6 GW across NEM and WEM."""
+    query = _unit_query()
+
+    assert "'battery_charging'" in query, "capacity sum must exclude the charging half"
+
+
+def test_bidirectional_row_is_still_excluded():
+    """The parent row carries the same megawatts again, so it cannot come back."""
+    assert "'battery'" in _unit_query()
+
+
+def test_discharging_half_is_kept():
+    """Battery capacity means generation capacity, consistent with every other fueltech in
+    this query, so the discharging half is the one that counts."""
+    query = _unit_query()
+
+    assert "'battery_discharging'" not in query, "the discharging half must remain in the sum"
+
+
+def test_power_and_energy_queries_keep_both_halves():
+    """Charge and discharge are distinct flows over time. Excluding a half there would drop
+    real generation, so the #488 fix must not have leaked into those queries."""
+    import inspect
+
+    from opennem.queries import energy, power
+
+    for module in (power, energy):
+        source = inspect.getsource(module)
+        assert "'battery_charging'" not in source, f"{module.__name__} must keep both battery halves"


### PR DESCRIPTION
refs #481.

## what happened

facility boundaries had never been imported on prod. dev had 264 from a july run that was never promoted; prod's `boundary` column was empty. running `bin/osm-import-boundaries.py` against prod imported **251 of 377** and failed on 126.

## the failures were one bug

**103 of the 126 are OSM relations whose ids are stored unsigned.** `get_osm_url` treats a negative id as a relation and a positive id as a way, so those were fetched as `/api/0.6/way/<id>` and returned either `410 Gone` or an unrelated line with no closed area.

most large wind and solar farms are mapped as relations rather than ways, so this hit the biggest sites specifically. the july `osm_location_comparison.csv` carries ids like `-12352856` that are stored today as `12352856`, so a sign-stripping pass at some point destroyed the type encoding.

## fix

try the id as a way, then as a relation, before failing. re-running the 126 failures recovered **64 more**, taking prod from 251 to **316 boundaries**.

| failure class | before fix | after fix |
|---|---|---|
| `410 Gone` | 46 | **0** |
| no polygon in the object | 80 | 59 |
| `404` | 0 | 2 |

the 410 class is gone entirely: every one was a relation. the 59 remaining are real absences, not a bug — the id resolves to a `type=site` relation grouping individual turbines, or to a line/node, so there is no closed area to store (ALBANY, BOCOROCK are examples). those need a different OSM feature or acceptance that only a point exists.

## also in this branch

`osm_candidates.csv` — proposed OSM matches for the 292 facilities still without a boundary, produced by pulling every mapped power area in Australia (604,658 areas, 764 named) and matching on name and distance. 103 confident, 110 for review, 79 with no mapped power feature within 8 km.

nothing is applied from it: `osm_way_id` is CMS-sourced (`cms/importer.py:205`), so a match only becomes real once accepted in Sanity.

## test plan

- ran against prod, numbers above
- ruff clean
- no schema change; the importer only fills null boundaries so it cannot overwrite
