### PR TITLE
fix(data): clamp negative generation on one-way units in unit_intervals

### DIFF
--- a/opennem/aggregates/unit_intervals.py
+++ b/opennem/aggregates/unit_intervals.py
@@ -53,6 +53,30 @@ logger = logging.getLogger("opennem.aggregates.unit_intervals")
 # reading so we never fabricate a whole missing interval.
 _ROOFTOP_LOOKBACK = timedelta(minutes=35)
 
+# Fueltechs whose meter may legitimately read negative, because the unit really does
+# consume from the grid as part of normal operation. Everything else is a one-way
+# generator: a negative reading is site or auxiliary load measured at the same point,
+# not negative generation, and is clamped to 0 below.
+#
+# This is the same rule already applied downstream in market_summary.py and the renewable
+# MVs; applying it here means every consumer of unit_intervals inherits it instead of each
+# one re-deriving it. Emissions, emission_factor and market_value already gate on
+# `energy > 0`, so they were consistent with the clamp before it existed.
+#
+# Scale of the correction, measured across all of unit_intervals before it was applied:
+# 1,562 GWh of negative energy against 2.2 million GWh positive, so ~0.07% overall and for
+# almost every unit an auxiliary draw that is tiny next to its output. It is concentrated
+# in one place. WEM PRK_AG (parkeston) alone is 1,009 of those 1,562 GWh, and is the only
+# unit the clamp materially changes: its scada point turned into a NET SITE METER at the
+# WEMDE cutover in Sep/Oct 2023 (before: 0 to +72 MW and never negative; after: -59 to
+# +72 MW, negative in 97% of intervals), so it reads gross generation minus the co-located
+# kalgoorlie load and we were publishing a 110 MW gas peaker as consuming ~355 GWh/yr
+# (#613). The load is real but it is not this generator's, and the gross figure is not
+# recoverable from the feed, so the honest series is generation-or-zero. See also #623 for
+# the dispatch-vs-facilityScada overwrite that shares the same root.
+_NEGATIVE_CAPABLE_FUELTECHS = ("battery", "battery_charging", "battery_discharging", "pumps")
+_NEGATIVE_CAPABLE_FUELTECHS_SQL = ", ".join(f"'{ft}'" for ft in _NEGATIVE_CAPABLE_FUELTECHS)
+
 
 def _monitor_memory_usage() -> float:
     """Monitor and log memory usage, trigger GC if needed.
@@ -210,8 +234,20 @@ async def _get_unit_interval_data(
             u.fueltech_id,
             ftg.code as fueltech_group_id,
             ftg.renewable as renewable,
-            round(sum(fs.generated), 4) as generated,
-            round(sum(fs.energy), 4) as energy,
+            -- Clamp one-way generators at 0: a negative reading is site/auxiliary load on
+            -- the same meter, not negative generation. See _NEGATIVE_CAPABLE_FUELTECHS.
+            -- Clamp the summed interval, not each row, so a unit that both draws and
+            -- generates within one 5-minute bucket nets out before the floor applies.
+            CASE
+                WHEN u.fueltech_id IN ({_NEGATIVE_CAPABLE_FUELTECHS_SQL})
+                    THEN round(sum(fs.generated), 4)
+                ELSE greatest(round(sum(fs.generated), 4), 0)
+            END as generated,
+            CASE
+                WHEN u.fueltech_id IN ({_NEGATIVE_CAPABLE_FUELTECHS_SQL})
+                    THEN round(sum(fs.energy), 4)
+                ELSE greatest(round(sum(fs.energy), 4), 0)
+            END as energy,
             round(sum(fs.energy_storage), 4) as energy_storage
         FROM
             facility_scada fs
@@ -449,8 +485,20 @@ async def _stream_unit_interval_data(
             u.fueltech_id,
             ftg.code as fueltech_group_id,
             ftg.renewable as renewable,
-            round(sum(fs.generated), 4) as generated,
-            round(sum(fs.energy), 4) as energy,
+            -- Clamp one-way generators at 0: a negative reading is site/auxiliary load on
+            -- the same meter, not negative generation. See _NEGATIVE_CAPABLE_FUELTECHS.
+            -- Clamp the summed interval, not each row, so a unit that both draws and
+            -- generates within one 5-minute bucket nets out before the floor applies.
+            CASE
+                WHEN u.fueltech_id IN ({_NEGATIVE_CAPABLE_FUELTECHS_SQL})
+                    THEN round(sum(fs.generated), 4)
+                ELSE greatest(round(sum(fs.generated), 4), 0)
+            END as generated,
+            CASE
+                WHEN u.fueltech_id IN ({_NEGATIVE_CAPABLE_FUELTECHS_SQL})
+                    THEN round(sum(fs.energy), 4)
+                ELSE greatest(round(sum(fs.energy), 4), 0)
+            END as energy,
             round(sum(fs.energy_storage), 4) as energy_storage
         FROM
             facility_scada fs

--- a/tests/test_unit_intervals_negative_clamp.py
+++ b/tests/test_unit_intervals_negative_clamp.py
@@ -1,0 +1,74 @@
+"""One-way generators cannot generate negative (#613).
+
+A negative reading on a generator's meter is site or auxiliary load measured at the same
+point, not negative generation, so `unit_intervals` floors it at 0. Storage and pumps are
+exempt because they really do consume as part of normal operation.
+
+The clamp is written into the aggregate SQL, so these tests pin the two things that can
+silently break it: the exempt set drifting, and the SQL losing the CASE for one of the two
+query builders (the CTE is duplicated between the batch and streaming paths).
+"""
+
+import inspect
+import re
+
+from opennem.aggregates import unit_intervals
+from opennem.aggregates.unit_intervals import (
+    _NEGATIVE_CAPABLE_FUELTECHS,
+    _NEGATIVE_CAPABLE_FUELTECHS_SQL,
+)
+
+_SOURCE = inspect.getsource(unit_intervals)
+
+
+def test_only_storage_and_pumps_may_read_negative():
+    """Adding a fueltech here silently republishes negative generation, so pin the set.
+
+    Batteries are the reason the clamp can't just be `greatest(x, 0)` everywhere: charging
+    is genuine consumption and floors would erase it.
+    """
+    assert set(_NEGATIVE_CAPABLE_FUELTECHS) == {
+        "battery",
+        "battery_charging",
+        "battery_discharging",
+        "pumps",
+    }
+
+
+def test_solar_rooftop_is_not_exempt():
+    """Rooftop is one-way. It is gap-filled separately but must never be negative-capable."""
+    assert "solar_rooftop" not in _NEGATIVE_CAPABLE_FUELTECHS
+
+
+def test_sql_fragment_quotes_every_fueltech():
+    """The constant is interpolated straight into an f-string SQL IN (...) list."""
+    for fueltech in _NEGATIVE_CAPABLE_FUELTECHS:
+        assert f"'{fueltech}'" in _NEGATIVE_CAPABLE_FUELTECHS_SQL
+
+    assert '"' not in _NEGATIVE_CAPABLE_FUELTECHS_SQL
+    assert ";" not in _NEGATIVE_CAPABLE_FUELTECHS_SQL
+
+
+def test_both_query_builders_clamp_generated_and_energy():
+    """The facility_data CTE is duplicated across the batch and streaming query builders.
+
+    Patching only one leaves negatives flowing through whichever path the worker happens to
+    take, which is exactly how this would regress. Both copies must carry both clamps.
+    """
+    generated_clamps = _SOURCE.count("ELSE greatest(round(sum(fs.generated), 4), 0)")
+    energy_clamps = _SOURCE.count("ELSE greatest(round(sum(fs.energy), 4), 0)")
+
+    assert generated_clamps == 2, f"expected both query builders to clamp generated, found {generated_clamps}"
+    assert energy_clamps == 2, f"expected both query builders to clamp energy, found {energy_clamps}"
+
+
+def test_no_unclamped_generated_sum_remains():
+    """Catch a future edit that reintroduces a bare sum in the facility_data projection."""
+    bare_projections = re.findall(r"^\s*round\(sum\(fs\.(?:generated|energy)\), 4\) as ", _SOURCE, re.MULTILINE)
+
+    assert not bare_projections, f"unclamped projection(s) reintroduced: {bare_projections}"
+
+
+def test_energy_storage_is_not_clamped():
+    """energy_storage is a state-of-charge measure, not a flow, and is left alone."""
+    assert "round(sum(fs.energy_storage), 4) as energy_storage" in _SOURCE


### PR DESCRIPTION
parkeston (`PRK_AG`) publishes ~355 GWh/yr of *negative* energy against a 110 MW gas peaker, which poisons wem facility energy and anything derived from it.

## what it actually is

the scada point became a **net site meter at the wemde cutover**, not a sign convention bug and not a mapping error:

| period | min | max | negative intervals |
|---|---|---|---|
| 2019-2022 | 0.0 MW | +72.4 MW | 0 |
| 2023-09 onward | -59.4 MW | +72.1 MW | 97% |

the flip lands exactly on the sep/oct 2023 wemde transition, when interval size also goes 30-min to 5-min. the old wem feed reported gross generation; the wemde `facilityScada` feed reports the site meter, which is gross generation minus the co-located kalgoorlie load. max export ~72 MW plus steady ~40 MW import ≈ the 110 MW nameplate, which is the arithmetic @nc9 and i landed on in the issue thread.

gross generation is not recoverable from the feed, so the honest series is generation-or-zero.

## the fix

a negative reading on a one-way generator is site or auxiliary load measured at the same point, not negative generation. `market_summary.py` and the renewable MVs **already** apply exactly this rule. this moves it up into `unit_intervals` so every consumer inherits it instead of each one re-deriving it. `emissions`, `emission_factor` and `market_value` already gated on `energy > 0`, so they were consistent with the clamp before it existed.

storage and pumps are exempt — charging is genuine consumption.

the clamp is applied to the summed 5-minute bucket rather than per row, so a unit that both draws and generates inside one interval nets out before the floor applies.

## blast radius

measured across all of `unit_intervals` before applying it: **1,562 GWh negative against 2.2m GWh positive, ~0.07%**, and it is concentrated in one place.

| unit | fueltech | negative | positive | net |
|---|---|---|---|---|
| `PRK_AG` | gas_ocgt | -1,008.84 | 381.42 | **-627.42** |
| `BWTR1` | bioenergy_biomass | -55.32 | 335.56 | 280.24 |
| `RPCG` | bioenergy_biomass | -35.43 | 526.08 | 490.65 |
| `COLLIE_G1` | coal_black | -27.70 | 32,104.62 | 32,076.92 |

`PRK_AG` is 1,009 of the 1,562 GWh and the only unit materially changed. the sugar mills (`BWTR1`, `RPCG`, `PIONEER`, `CONDONG1`) are the same shape at a much smaller scale — they draw from the grid when not crushing. only `PRK_AG` and `BBTHREE3` (-3.69 GWh) are net-negative over all history.

## verification

against prod rows, the exact `CASE` expression:

```
COLLIE_G1  coal_black  raw_min -10.97  clamped_min 0.00  raw_neg 1125  clamped_neg 0
PRK_AG     gas_ocgt    raw_min -53.93  clamped_min 0.00  raw_neg 2016  clamped_neg 0
VBB1       battery     raw_min -222.30 clamped_min -222.30  raw_neg 320  clamped_neg 320
TIB1       battery     raw_min -204.43 clamped_min -204.43  raw_neg 257  clamped_neg 257
BLYTHB1    battery     raw_min -201.04 clamped_min -201.04  raw_neg 336  clamped_neg 336
```

and running the real aggregate over a wem day: 21,189 rows, `PRK_AG` now flat 0, zero non-storage rows negative, batteries untouched.

6 tests pin the exempt set and assert **both** query builders carry the clamp — the `facility_data` CTE is duplicated between the batch and streaming paths, and patching only one is exactly how this would regress.

## note

raw `facility_scada` is untouched, so aemo's published value is preserved and this is reversible. **takes effect on re-aggregation** — wem from 2023-09 still needs to be re-run.

fixes #613, refs #623
