### PR TITLE
fix(cms): stop the synthetic 0 prefix swallowing a real facility

### DIFF
--- a/opennem/cms/importer.py
+++ b/opennem/cms/importer.py
@@ -34,10 +34,29 @@ from opennem.core.networks import network_from_network_code
 from opennem.db import get_read_session, get_write_session, retry_on_deadlock
 from opennem.db.models.opennem import Facility, Unit
 from opennem.schema.facility import FacilitySchema
-from opennem.schema.unit import UnitStatusType
+from opennem.schema.unit import UnitSchema, UnitStatusType
 from opennem.workers.facility_data_seen import update_facility_seen_range
 
 logger = logging.getLogger("sanity.importer")
+
+
+def _resolved_codes(record: FacilitySchema | UnitSchema) -> tuple[str, str]:
+    """Operational and display code for a facility or unit.
+
+    `_validate_unique_codes` resolves these against the whole CMS payload, because whether a
+    leading "0" is a synthetic prefix or part of a real code depends on what every other
+    record has claimed (#481). Re-deriving them here with `strip_synthetic_prefix` alone
+    would reach a different answer for a collision and reintroduce the bug.
+
+    Falls back to the local strip for callers that build a schema outside the validated
+    sync path, where there is no payload to resolve against.
+    """
+    operational, display = record.operational_code, record.display_code
+
+    if operational and display:
+        return operational, display
+
+    return strip_synthetic_prefix(record.code)
 
 
 def get_opennem_stations() -> list[dict]:
@@ -119,7 +138,7 @@ async def create_or_update_database_facility(facility: FacilitySchema, send_slac
                 logger.info(f"Would create new facility: {facility.code} - {facility.name}")
                 return False
 
-            facility_operational_code, facility_display_code = strip_synthetic_prefix(facility.code)
+            facility_operational_code, facility_display_code = _resolved_codes(facility)
 
             facility_db = Facility(
                 code=facility_operational_code,
@@ -163,7 +182,7 @@ async def create_or_update_database_facility(facility: FacilitySchema, send_slac
             record_updated = True
 
         if facility.code:
-            facility_op_code, facility_disp_code = strip_synthetic_prefix(facility.code)
+            facility_op_code, facility_disp_code = _resolved_codes(facility)
             if facility_op_code != facility_db.code:
                 facility_db.code = facility_op_code
                 record_updated = True
@@ -277,7 +296,7 @@ async def create_or_update_database_facility(facility: FacilitySchema, send_slac
                     else None
                 )
 
-                unit_operational_code, unit_display_code = strip_synthetic_prefix(unit.code)
+                unit_operational_code, unit_display_code = _resolved_codes(unit)
 
                 unit_db = Unit(
                     code=unit_operational_code,
@@ -369,7 +388,7 @@ async def create_or_update_database_facility(facility: FacilitySchema, send_slac
 
             # Always update all unit metadata from CMS
             if unit.code:
-                unit_op_code, unit_disp_code = strip_synthetic_prefix(unit.code)
+                unit_op_code, unit_disp_code = _resolved_codes(unit)
                 if unit_op_code != unit_db.code:
                     unit_db.code = unit_op_code  # type: ignore
                     record_updated = True

--- a/opennem/cms/queries.py
+++ b/opennem/cms/queries.py
@@ -35,7 +35,7 @@ from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_ex
 
 from opennem import settings
 from opennem.cms.client import sanity_client
-from opennem.cms.utils import strip_synthetic_prefix
+from opennem.cms.utils import resolve_operational_code, strip_synthetic_prefix
 from opennem.schema.facility import FacilityPhotoOutputSchema, FacilitySchema
 from opennem.schema.unit import UnitSchema
 
@@ -207,53 +207,71 @@ def get_unit_factors() -> list[dict]:
 
 
 def _validate_unique_codes(facilities: list[FacilitySchema]) -> list[FacilitySchema]:
-    """Validate unique codes and deduplicate synthetic/real collisions.
+    """Validate unique codes and resolve synthetic/real collisions.
 
-    Checks for duplicate codes using stripped operational codes (no "0" prefix).
-    When a synthetic (0-prefixed) facility collides with a real one, the synthetic
-    is dropped with a warning. True duplicates (same raw code) still raise.
+    Codes are compared on their operational form (no synthetic "0" prefix). A synthetic
+    code whose stripped form is claimed by a *different* record keeps its prefix instead of
+    being stripped, so both records survive; see `resolve_operational_code`. True duplicates
+    (two records with the same raw code) still raise.
+
+    The resolved codes are written back onto each schema as `operational_code` /
+    `display_code` so the importer persists exactly what was validated here rather than
+    re-deriving it and reaching a different answer.
 
     Returns:
-        Filtered list with synthetic duplicates removed.
+        The facilities, with codes resolved. Nothing is dropped for a prefix collision.
     """
+    # Resolve against every raw code in the payload before assigning any, so the outcome
+    # does not depend on which of a colliding pair happens to come first in the list.
+    raw_facility_codes = {f.code for f in facilities if f.code}
+    raw_unit_codes = {u.code for f in facilities for u in (f.units or []) if u.code}
+
     facility_codes: dict[str, str] = {}
     unit_codes: dict[str, str] = {}
-    filtered_facilities: list[FacilitySchema] = []
 
     for facility in facilities:
         if not facility.code:
             raise CMSQueryError(f"Facility missing code (facility id: {facility.cms_id})")
 
-        facility_op_code, _ = strip_synthetic_prefix(facility.code)
+        facility_op_code, facility_disp_code = resolve_operational_code(facility.code, raw_facility_codes - {facility.code})
+
         if facility_op_code in facility_codes:
             existing_code = facility_codes[facility_op_code]
-            if existing_code != facility.code:
-                # Synthetic/real collision — skip synthetic
-                logger.warning(f"Skipping duplicate facility {facility.code} (collides with {existing_code})")
-                continue
             raise DuplicateCodeError(
                 f"Duplicate facility code: {facility.code} (first: {existing_code}, second: {facility.cms_id})"
             )
+
+        if strip_synthetic_prefix(facility.code)[0] != facility_op_code:
+            logger.info(f"Keeping synthetic prefix on facility {facility.code} (stripped code belongs to another facility)")
+
         facility_codes[facility_op_code] = facility.code
+        facility.operational_code = facility_op_code
+        facility.display_code = facility_disp_code
+
+        # Units keep the pre-existing skip-with-warning behaviour on a genuine duplicate.
+        # After prefix resolution the only way to land here is two units sharing a raw code,
+        # which is a CMS authoring error rather than something this function can resolve.
+        kept_units = []
+        for unit in facility.units or []:
+            if not unit.code:
+                raise CMSQueryError(f"Unit missing code in facility: {facility.code}")
+
+            unit_op_code, unit_disp_code = resolve_operational_code(unit.code, raw_unit_codes - {unit.code})
+
+            if unit_op_code in unit_codes:
+                existing_fac = unit_codes[unit_op_code]
+                logger.warning(f"Skipping duplicate unit {unit.code} in {facility.code} (collides with {existing_fac})")
+                continue
+
+            unit_codes[unit_op_code] = facility.code
+            unit.operational_code = unit_op_code
+            unit.display_code = unit_disp_code
+            kept_units.append(unit)
 
         if facility.units:
-            filtered_units = []
-            for unit in facility.units:
-                if not unit.code:
-                    raise CMSQueryError(f"Unit missing code in facility: {facility.code}")
+            facility.units = kept_units
 
-                unit_op_code, _ = strip_synthetic_prefix(unit.code)
-                if unit_op_code in unit_codes:
-                    existing_fac = unit_codes[unit_op_code]
-                    logger.warning(f"Skipping duplicate unit {unit.code} in {facility.code} (collides with {existing_fac})")
-                    continue
-                unit_codes[unit_op_code] = facility.code
-                filtered_units.append(unit)
-            facility.units = filtered_units
-
-        filtered_facilities.append(facility)
-
-    return filtered_facilities
+    return facilities
 
 
 # Transient CMS errors worth retrying. The sanity client raises its own exception types

--- a/opennem/cms/utils.py
+++ b/opennem/cms/utils.py
@@ -1,8 +1,35 @@
 """CMS utility functions."""
 
+from collections.abc import Container
+
 
 def strip_synthetic_prefix(code: str) -> tuple[str, str]:
     """Strip leading '0' from synthetic DUIDs. Returns (operational_code, display_code)."""
     if code and len(code) > 1 and code[0] == "0" and code[1].isalpha():
         return code[1:], code
     return code, code
+
+
+def resolve_operational_code(code: str, reserved: Container[str]) -> tuple[str, str]:
+    """Strip the synthetic prefix, unless the stripped code belongs to something else.
+
+    The '0' prefix marks a code OpenNEM invented — a derived battery unit, or a placeholder
+    for a facility whose real DUID isn't known yet — and stripping it recovers the
+    operational code. That only holds while the stripped result is unclaimed. `0WNSF`
+    (Winton North, committed, no data) strips to `WNSF`, which is a real and entirely
+    different facility (Wangaratta), and the collision meant Winton North was silently
+    dropped from every sync (#481).
+
+    When the stripped code is already claimed, the prefix is not synthetic-in-context and
+    the code is kept whole, so both facilities survive the sync.
+
+    Args:
+        code: the raw code as held in the CMS
+        reserved: codes claimed by other records — must not contain `code` itself
+    """
+    operational, display = strip_synthetic_prefix(code)
+
+    if operational != code and operational in reserved:
+        return code, code
+
+    return operational, display

--- a/opennem/schema/facility.py
+++ b/opennem/schema/facility.py
@@ -60,6 +60,13 @@ class FacilitySchema(BaseModel):
     location: FacilityLocationSchema | None = None
     units: list[UnitSchema]
 
+    # Codes resolved by _validate_unique_codes against the whole payload: operational_code
+    # is what Postgres stores, display_code keeps the synthetic "0" prefix for display.
+    # Set after parsing rather than read from the CMS, since resolving a synthetic prefix
+    # needs to know which codes every other facility has claimed (#481).
+    operational_code: str | None = None
+    display_code: str | None = None
+
     # Sanity fields
     updated_at: datetime | None = None
     cms_id: str | None = Field(None, alias="_id")

--- a/opennem/schema/unit.py
+++ b/opennem/schema/unit.py
@@ -150,6 +150,9 @@ class UnitSchema(BaseModel):
     """Facility output schema"""
 
     code: DUIDType
+    # Resolved by _validate_unique_codes against the whole payload — see FacilitySchema.
+    operational_code: str | None = None
+    display_code: str | None = None
     dispatch_type: UnitDispatchType
     fueltech_id: UnitFueltechType
     status_id: UnitStatusType

--- a/tests/test_cms_synthetic_code_collision.py
+++ b/tests/test_cms_synthetic_code_collision.py
@@ -1,0 +1,91 @@
+"""Synthetic "0" prefix must not swallow a real facility (#481).
+
+The prefix marks a code OpenNEM invented, and stripping it recovers the operational code.
+That only holds while the stripped result is unclaimed: `0WNSF` (Winton North) strips to
+`WNSF`, which is a real and entirely different facility (Wangaratta). The old rule dropped
+whichever one it saw second, so Winton North never reached Postgres — its CMS location and
+osm_way_id were correct and unreachable.
+"""
+
+import pytest
+
+from opennem.cms.queries import DuplicateCodeError, _validate_unique_codes
+from opennem.cms.utils import resolve_operational_code, strip_synthetic_prefix
+from opennem.schema.facility import FacilitySchema
+
+
+def _facility(code: str, cms_id: str, unit_codes: list[str] | None = None) -> FacilitySchema:
+    return FacilitySchema(
+        code=code,
+        name=code.title(),
+        network_id="NEM",
+        network_region="NSW1",
+        _id=cms_id,
+        units=[
+            {
+                "code": unit_code,
+                "dispatch_type": "GENERATOR",
+                "fueltech_id": "solar_utility",
+                "status_id": "operating",
+            }
+            for unit_code in (unit_codes or [f"{code}1"])
+        ],
+    )
+
+
+class TestResolveOperationalCode:
+    def test_strips_an_unclaimed_synthetic_prefix(self):
+        assert resolve_operational_code("0QBYNBG1", reserved=set()) == ("QBYNBG1", "0QBYNBG1")
+
+    def test_keeps_the_prefix_when_the_stripped_code_is_claimed(self):
+        assert resolve_operational_code("0WNSF", reserved={"WNSF"}) == ("0WNSF", "0WNSF")
+
+    def test_leaves_a_non_synthetic_code_alone(self):
+        assert resolve_operational_code("WNSF", reserved={"0WNSF"}) == ("WNSF", "WNSF")
+
+    def test_a_leading_zero_before_a_digit_is_not_a_prefix(self):
+        """Only 0-then-letter is the synthetic marker, matching strip_synthetic_prefix."""
+        assert resolve_operational_code("01ABC", reserved=set()) == strip_synthetic_prefix("01ABC")
+
+
+class TestValidateUniqueCodes:
+    def test_both_facilities_survive_a_prefix_collision(self):
+        facilities = _validate_unique_codes([_facility("0WNSF", "cms-winton"), _facility("WNSF", "cms-wangaratta")])
+
+        assert len(facilities) == 2
+        by_code = {f.code: f for f in facilities}
+        assert by_code["0WNSF"].operational_code == "0WNSF"
+        assert by_code["WNSF"].operational_code == "WNSF"
+
+    @pytest.mark.parametrize("order", [("0WNSF", "WNSF"), ("WNSF", "0WNSF")])
+    def test_resolution_does_not_depend_on_payload_order(self, order):
+        """The old rule kept whichever came first, so the real facility could be the one dropped."""
+        facilities = _validate_unique_codes([_facility(code, f"cms-{code}") for code in order])
+
+        assert {f.operational_code for f in facilities} == {"0WNSF", "WNSF"}
+        assert len(facilities) == 2
+
+    def test_synthetic_prefix_is_still_stripped_when_uncontested(self):
+        """The QBYNB battery split is the normal case and must keep working."""
+        facilities = _validate_unique_codes([_facility("QBYNB", "cms-q", ["QBYNB1", "0QBYNBG1", "0QBYNBL1"])])
+
+        units = {u.code: u for u in facilities[0].units}
+        assert units["0QBYNBG1"].operational_code == "QBYNBG1"
+        assert units["0QBYNBG1"].display_code == "0QBYNBG1"
+        assert units["QBYNB1"].operational_code == "QBYNB1"
+
+    def test_colliding_unit_codes_across_facilities_both_survive(self):
+        facilities = _validate_unique_codes([_facility("WINTONN", "cms-a", ["0WNSF1"]), _facility("WANGA", "cms-b", ["WNSF1"])])
+
+        resolved = {u.code: u.operational_code for f in facilities for u in f.units}
+        assert resolved == {"0WNSF1": "0WNSF1", "WNSF1": "WNSF1"}
+
+    def test_a_true_duplicate_still_raises(self):
+        with pytest.raises(DuplicateCodeError):
+            _validate_unique_codes([_facility("WNSF", "cms-a"), _facility("WNSF", "cms-b")])
+
+    def test_nothing_is_dropped_for_a_prefix_collision(self):
+        """Regression guard: the failure mode was silent, so assert on the count directly."""
+        payload = [_facility("0WNSF", "cms-1"), _facility("WNSF", "cms-2"), _facility("QBYNB", "cms-3")]
+
+        assert len(_validate_unique_codes(payload)) == 3


### PR DESCRIPTION
`0WNSF` (winton north) strips to `WNSF`, which is a real and **entirely different** facility (wangaratta). the dedup rule read that as a synthetic/real collision and dropped whichever it saw second, so winton north never reached postgres. its CMS `location` and `osm_way_id` were correct the whole time and simply unreachable, and the only signal was a single warning line in the sync log:

```
Skipping duplicate facility 0WNSF (collides with WNSF)
```

found while applying the #481 geo batch — a spot-check count came out one short.

| | code | name | status | osm_way_id in CMS |
|---|---|---|---|---|
| synthetic | `0WNSF` | Winton North | committed, 131 MW | `948218698` (never synced) |
| real | `WNSF` | Wangaratta | operating, 26.4 MW | `1547710194` |

## the rule

the `0` prefix marks a code we invented — a derived battery unit like `0QBYNBG1`, or a placeholder for a facility whose real DUID isn't known yet — and stripping it recovers the operational code. that only holds **while the stripped result is unclaimed**.

`resolve_operational_code` keeps the prefix when the stripped form belongs to another record. both facilities then survive, and `0WNSF` stays `0WNSF` rather than fighting wangaratta for `WNSF`.

two supporting changes:

- **resolution runs against the whole payload before any code is assigned.** the old loop assigned as it went, so the outcome depended on list order — with the order reversed it would have dropped the *real* wangaratta instead. there is a parametrised test for exactly this.
- **resolved codes are written onto the schema** as `operational_code` / `display_code`, and the importer reads those. it previously called `strip_synthetic_prefix` again at four sites, which would reach a different answer for a collision and reintroduce the bug one layer down.

unit handling keeps its existing skip-with-warning on a genuine duplicate; after prefix resolution the only way to land there is two units sharing a raw code, which is a CMS authoring error.

## verified against the live CMS

```
Keeping synthetic prefix on facility 0WNSF (stripped code belongs to another facility)
facilities returned: 616
  0WNSF   op=0WNSF   disp=0WNSF   osm='948218698'   loc=-36.502154,146.125175
  WNSF    op=WNSF    disp=WNSF    osm='1547710194'  loc=-36.323808,146.366
  QBYNB   op=QBYNB   disp=QBYNB
      unit 0QBYNBG1  op=QBYNBG1   disp=0QBYNBG1
      unit 0QBYNBL1  op=QBYNBL1   disp=0QBYNBL1
```

winton north is back, wangaratta is untouched, and the QBYNB battery split still strips normally.

postgres already holds the matching `cms_id` (`f6fe7625-…`) and `code_display=0WNSF`, so the sync updates the existing row in place — no rename, no duplicate row.

11 tests cover the resolver and the validator, including order-independence, the uncontested strip, and a count assertion as a regression guard, since the failure mode was silent.

refs #481
