### PR TITLE
fix(cms): let the CMS clear an osm_way_id, and drop the stale boundary with it

### DIFF
--- a/opennem/cms/importer.py
+++ b/opennem/cms/importer.py
@@ -40,6 +40,15 @@ from opennem.workers.facility_data_seen import update_facility_seen_range
 logger = logging.getLogger("sanity.importer")
 
 
+def normalise_osm_way_id(value: str | None) -> str | None:
+    """Trim an osm way id, collapsing blank to None so it clears rather than storing "".
+
+    A whitespace-only value from the CMS must read as "no link", not as a link to an empty
+    string, or the column stays truthy and the boundary is never retracted.
+    """
+    return (value or "").strip() or None
+
+
 def _resolved_codes(record: FacilitySchema | UnitSchema) -> tuple[str, str]:
     """Operational and display code for a facility or unit.
 
@@ -220,9 +229,23 @@ async def create_or_update_database_facility(facility: FacilitySchema, send_slac
             facility_db.cms_id = facility.cms_id
             record_updated = True
 
-        # Update new fields
-        if hasattr(facility, "osm_way_id") and facility.osm_way_id:
-            facility_db.osm_way_id = facility.osm_way_id.strip()
+        # Update new fields.
+        #
+        # osm_way_id syncs unconditionally, including to NULL. The truthy guard the other
+        # fields use meant clearing a link in the CMS had no effect downstream, so a wrong
+        # match was permanent: TESLA_PICTON (WA) kept pointing at Pindari Power Station in
+        # NSW, 3,392 km away, and kept serving that boundary, even after the id was removed
+        # from Sanity (#481).
+        #
+        # boundary is derived from osm_way_id by bin/osm-import-boundaries.py, which only
+        # fills rows where boundary IS NULL and so would never retract a stale polygon.
+        # Dropping the link has to drop the geometry with it or the wrong shape outlives it.
+        osm_way_id = normalise_osm_way_id(facility.osm_way_id)
+        if osm_way_id != facility_db.osm_way_id:
+            if osm_way_id is None:
+                logger.info(f"Clearing osm_way_id {facility_db.osm_way_id} and boundary for {facility.code}")
+                facility_db.boundary = None
+            facility_db.osm_way_id = osm_way_id
             record_updated = True
 
         if hasattr(facility, "npi_id") and facility.npi_id:

--- a/tests/test_cms_clear_osm_link.py
+++ b/tests/test_cms_clear_osm_link.py
@@ -1,0 +1,51 @@
+"""Removing an osm_way_id in the CMS must clear it, and its boundary, in Postgres (#481).
+
+Every other field in the importer syncs behind a truthy guard, which silently makes a value
+un-removable. For osm_way_id that meant a wrong match was permanent: TESLA_PICTON (Picton,
+WA) kept pointing at Pindari Power Station in NSW and kept serving that boundary long after
+the id was removed from Sanity.
+
+The boundary is derived from the link by bin/osm-import-boundaries.py, which only fills rows
+where boundary IS NULL and so never retracts a stale polygon on its own.
+"""
+
+import inspect
+
+import pytest
+
+from opennem.cms import importer
+from opennem.cms.importer import normalise_osm_way_id
+
+_SOURCE = inspect.getsource(importer)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("366249341", "366249341"),
+        ("  366249341  ", "366249341"),
+        ("-10059368", "-10059368"),  # negative ids encode a relation rather than a way
+        (None, None),
+        ("", None),
+        ("   ", None),
+    ],
+)
+def test_normalise_osm_way_id(value, expected):
+    assert normalise_osm_way_id(value) == expected
+
+
+def test_blank_normalises_to_none_not_empty_string():
+    """An empty string is truthy enough to keep a stale boundary alive, so it must be None."""
+    assert normalise_osm_way_id("") is None
+    assert normalise_osm_way_id("  ") is None
+
+
+def test_osm_way_id_is_not_behind_a_truthy_guard():
+    """The exact shape of the original bug — guard the guard."""
+    assert 'if hasattr(facility, "osm_way_id") and facility.osm_way_id:' not in _SOURCE
+    assert "osm_way_id = normalise_osm_way_id(facility.osm_way_id)" in _SOURCE
+
+
+def test_clearing_the_link_also_clears_the_boundary():
+    """A dropped link must drop the derived geometry, or the wrong shape outlives it."""
+    assert "facility_db.boundary = None" in _SOURCE


### PR DESCRIPTION
`osm_way_id` synced behind a truthy guard:

```python
if hasattr(facility, "osm_way_id") and facility.osm_way_id:
    facility_db.osm_way_id = facility.osm_way_id.strip()
```

so removing it in sanity had no effect on postgres, and a wrong match was **permanent**.

found finishing off the #481 residue. `TESLA_PICTON` (picton, WA) carried `way/366249341`, which is pindari power station in NSW, **3,392 km away**. the id was cleared in the CMS during the review; a full `cms-sync` afterwards left postgres exactly as it was, still serving pindari's polygon on picton's facility page.

## boundary has to go too

`boundary` is derived from the link by `bin/osm-import-boundaries.py`, which only fills rows `WHERE boundary IS NULL`. it never retracts. so dropping a link without dropping the geometry leaves the wrong shape in place with nothing pointing at it, which is strictly worse than before — the id that explained it is gone.

## change

`osm_way_id` syncs unconditionally, including to NULL, and clearing it nulls the boundary in the same update. blank normalises to `None` via a small `normalise_osm_way_id` helper, so a whitespace-only CMS value reads as "no link" rather than a link to an empty string that would stay truthy and keep the polygon alive.

## verified on dev

```
Clearing osm_way_id 366249341 and boundary for TESLA_PICTON
Sync complete: 0 facilities created, 1 facilities updated, 0 failed
```

```
code         | osm       | has_boundary
PINDARI      | 366249341 | t
TESLA_PICTON | (null)    | f
```

pindari keeps its own link and boundary; only picton is retracted.

## scope

deliberately narrow. the other fields (`npi_id`, `location`, `description`) still have the same truthy guard and the same inability to be cleared. that is worth a sweep, but each needs its own think about what a null means, and `osm_way_id` is the one with a derived artefact hanging off it and a live wrong value in prod today.

refs #481
